### PR TITLE
Add local ISO upload via UI

### DIFF
--- a/api/src/main/java/com/cloud/template/TemplateApiService.java
+++ b/api/src/main/java/com/cloud/template/TemplateApiService.java
@@ -24,6 +24,7 @@ import org.apache.cloudstack.api.BaseListTemplateOrIsoPermissionsCmd;
 import org.apache.cloudstack.api.BaseUpdateTemplateOrIsoPermissionsCmd;
 import org.apache.cloudstack.api.command.user.iso.DeleteIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.ExtractIsoCmd;
+import org.apache.cloudstack.api.command.user.iso.GetUploadParamsForIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.RegisterIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.UpdateIsoCmd;
 import org.apache.cloudstack.api.command.user.template.CopyTemplateCmd;
@@ -45,9 +46,11 @@ public interface TemplateApiService {
 
     VirtualMachineTemplate registerTemplate(RegisterTemplateCmd cmd) throws URISyntaxException, ResourceAllocationException;
 
-    public GetUploadParamsResponse registerTemplateForPostUpload(GetUploadParamsForTemplateCmd cmd) throws ResourceAllocationException, MalformedURLException;
+    GetUploadParamsResponse registerTemplateForPostUpload(GetUploadParamsForTemplateCmd cmd) throws ResourceAllocationException, MalformedURLException;
 
     VirtualMachineTemplate registerIso(RegisterIsoCmd cmd) throws IllegalArgumentException, ResourceAllocationException;
+
+    GetUploadParamsResponse registerIsoForPostUpload(GetUploadParamsForIsoCmd cmd) throws ResourceAllocationException, MalformedURLException;
 
     VirtualMachineTemplate copyTemplate(CopyTemplateCmd cmd) throws StorageUnavailableException, ResourceAllocationException;
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/iso/GetUploadParamsForIsoCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/iso/GetUploadParamsForIsoCmd.java
@@ -1,0 +1,158 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.user.iso;
+
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.AbstractGetUploadParamsCmd;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.GetUploadParamsResponse;
+import org.apache.cloudstack.api.response.GuestOSResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
+import org.apache.cloudstack.context.CallContext;
+
+import java.net.MalformedURLException;
+
+@APICommand(name = GetUploadParamsForIsoCmd.APINAME,
+        description = "upload an existing ISO into the CloudStack cloud.",
+        responseObject = GetUploadParamsResponse.class, since = "4.11.2",
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+public class GetUploadParamsForIsoCmd extends AbstractGetUploadParamsCmd {
+
+    public static final String APINAME = "getUploadParamsForIso";
+
+    private static final String s_name = "postuploadisoresponse";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.BOOTABLE, type = BaseCmd.CommandType.BOOLEAN, description = "true if this ISO is bootable. If not passed explicitly its assumed to be true")
+    private Boolean bootable;
+
+    @Parameter(name = ApiConstants.DISPLAY_TEXT,
+            type = BaseCmd.CommandType.STRING,
+            required = true,
+            description = "the display text of the ISO. This is usually used for display purposes.",
+            length = 4096)
+    private String displayText;
+
+    @Parameter(name = ApiConstants.IS_FEATURED, type = BaseCmd.CommandType.BOOLEAN, description = "true if you want this ISO to be featured")
+    private Boolean featured;
+
+    @Parameter(name = ApiConstants.IS_PUBLIC,
+            type = BaseCmd.CommandType.BOOLEAN,
+            description = "true if you want to register the ISO to be publicly available to all users, false otherwise.")
+    private Boolean publicIso;
+
+    @Parameter(name = ApiConstants.IS_EXTRACTABLE, type = BaseCmd.CommandType.BOOLEAN, description = "true if the ISO or its derivatives are extractable; default is false")
+    private Boolean extractable;
+
+    @Parameter(name = ApiConstants.NAME, type = BaseCmd.CommandType.STRING, required = true, description = "the name of the ISO")
+    private String isoName;
+
+    @Parameter(name = ApiConstants.OS_TYPE_ID,
+            type = BaseCmd.CommandType.UUID,
+            entityType = GuestOSResponse.class,
+            description = "the ID of the OS type that best represents the OS of this ISO. If the ISO is bootable this parameter needs to be passed")
+    private Long osTypeId;
+
+    @Parameter(name=ApiConstants.ZONE_ID, type= BaseCmd.CommandType.UUID, entityType = ZoneResponse.class,
+            required=true, description="the ID of the zone you wish to register the ISO to.")
+    protected Long zoneId;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Boolean isBootable() {
+        return bootable;
+    }
+
+    public String getDisplayText() {
+        return displayText;
+    }
+
+    public Boolean isFeatured() {
+        return featured;
+    }
+
+    public Boolean isPublic() {
+        return publicIso;
+    }
+
+    public Boolean isExtractable() {
+        return extractable;
+    }
+
+    public String getIsoName() {
+        return isoName;
+    }
+
+    public Long getOsTypeId() {
+        return osTypeId;
+    }
+
+    public Long getZoneId() {
+        return zoneId;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        validateRequest();
+        try {
+            GetUploadParamsResponse response = _templateService.registerIsoForPostUpload(this);
+            response.setResponseName(getCommandName());
+            setResponseObject(response);
+        } catch (ResourceAllocationException | MalformedURLException e) {
+            s_logger.error("Exception while registering template", e);
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Exception while registering ISO: " + e.getMessage());
+        }
+    }
+
+    private void validateRequest() {
+        if (getZoneId() <= 0) {
+            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Invalid zoneid");
+        }
+    }
+
+    @Override
+    public String getCommandName() {
+        return s_name;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        Long accountId = _accountService.finalyzeAccountId(getAccountName(), getDomainId(), getProjectId(), true);
+        if (accountId == null) {
+            return CallContext.current().getCallingAccount().getId();
+        }
+        return accountId;
+    }
+}

--- a/plugins/hypervisors/baremetal/src/main/java/com/cloud/baremetal/manager/BareMetalTemplateAdapter.java
+++ b/plugins/hypervisors/baremetal/src/main/java/com/cloud/baremetal/manager/BareMetalTemplateAdapter.java
@@ -40,6 +40,7 @@ import com.cloud.user.Account;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.exception.CloudRuntimeException;
 import org.apache.cloudstack.api.command.user.iso.DeleteIsoCmd;
+import org.apache.cloudstack.api.command.user.iso.GetUploadParamsForIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.RegisterIsoCmd;
 import org.apache.cloudstack.api.command.user.template.RegisterTemplateCmd;
 import org.apache.cloudstack.storage.command.TemplateOrVolumePostUploadCommand;
@@ -69,6 +70,11 @@ public class BareMetalTemplateAdapter extends TemplateAdapterBase implements Tem
 
     @Override
     public TemplateProfile prepare(RegisterIsoCmd cmd) throws ResourceAllocationException {
+        throw new CloudRuntimeException("Baremetal doesn't support ISO template");
+    }
+
+    @Override
+    public TemplateProfile prepare(GetUploadParamsForIsoCmd cmd) throws ResourceAllocationException {
         throw new CloudRuntimeException("Baremetal doesn't support ISO template");
     }
 

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -338,6 +338,7 @@ import org.apache.cloudstack.api.command.user.iso.CopyIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.DeleteIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.DetachIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.ExtractIsoCmd;
+import org.apache.cloudstack.api.command.user.iso.GetUploadParamsForIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.ListIsoPermissionsCmd;
 import org.apache.cloudstack.api.command.user.iso.ListIsosCmd;
 import org.apache.cloudstack.api.command.user.iso.RegisterIsoCmd;
@@ -3070,6 +3071,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(DeleteManagementNetworkIpRangeCmd.class);
         cmdList.add(UploadTemplateDirectDownloadCertificate.class);
         cmdList.add(ListMgmtsCmd.class);
+        cmdList.add(GetUploadParamsForIsoCmd.class);
 
         // Out-of-band management APIs for admins
         cmdList.add(EnableOutOfBandManagementForHostCmd.class);

--- a/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/HypervisorTemplateAdapter.java
@@ -35,6 +35,7 @@ import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionStatus;
 import org.apache.cloudstack.agent.directdownload.CheckUrlAnswer;
 import org.apache.cloudstack.agent.directdownload.CheckUrlCommand;
+import org.apache.cloudstack.api.command.user.iso.GetUploadParamsForIsoCmd;
 import org.apache.cloudstack.api.command.user.template.GetUploadParamsForTemplateCmd;
 import org.apache.cloudstack.engine.subsystem.api.storage.DataObject;
 import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
@@ -163,6 +164,15 @@ public class HypervisorTemplateAdapter extends TemplateAdapterBase {
         profile.setUrl(url);
         // Check that the resource limit for secondary storage won't be exceeded
         _resourceLimitMgr.checkResourceLimit(_accountMgr.getAccount(cmd.getEntityOwnerId()), ResourceType.secondary_storage, UriUtils.getRemoteSize(url));
+        return profile;
+    }
+
+    @Override
+    public TemplateProfile prepare(GetUploadParamsForIsoCmd cmd) throws ResourceAllocationException {
+        TemplateProfile profile = super.prepare(cmd);
+
+        // Check that the resource limit for secondary storage won't be exceeded
+        _resourceLimitMgr.checkResourceLimit(_accountMgr.getAccount(cmd.getEntityOwnerId()), ResourceType.secondary_storage);
         return profile;
     }
 

--- a/server/src/main/java/com/cloud/template/TemplateAdapter.java
+++ b/server/src/main/java/com/cloud/template/TemplateAdapter.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.cloudstack.api.command.user.iso.DeleteIsoCmd;
+import org.apache.cloudstack.api.command.user.iso.GetUploadParamsForIsoCmd;
 import org.apache.cloudstack.api.command.user.iso.RegisterIsoCmd;
 import org.apache.cloudstack.api.command.user.template.DeleteTemplateCmd;
 import org.apache.cloudstack.api.command.user.template.ExtractTemplateCmd;
@@ -51,29 +52,31 @@ public interface TemplateAdapter extends Adapter {
         }
     }
 
-    public TemplateProfile prepare(RegisterTemplateCmd cmd) throws ResourceAllocationException;
+    TemplateProfile prepare(RegisterTemplateCmd cmd) throws ResourceAllocationException;
 
-    public TemplateProfile prepare(GetUploadParamsForTemplateCmd cmd) throws ResourceAllocationException;
+    TemplateProfile prepare(GetUploadParamsForTemplateCmd cmd) throws ResourceAllocationException;
 
-    public TemplateProfile prepare(RegisterIsoCmd cmd) throws ResourceAllocationException;
+    TemplateProfile prepare(RegisterIsoCmd cmd) throws ResourceAllocationException;
 
-    public VMTemplateVO create(TemplateProfile profile);
+    TemplateProfile prepare(GetUploadParamsForIsoCmd cmd) throws ResourceAllocationException;
 
-    public List<TemplateOrVolumePostUploadCommand> createTemplateForPostUpload(TemplateProfile profile);
+    VMTemplateVO create(TemplateProfile profile);
 
-    public TemplateProfile prepareDelete(DeleteTemplateCmd cmd);
+    List<TemplateOrVolumePostUploadCommand> createTemplateForPostUpload(TemplateProfile profile);
 
-    public TemplateProfile prepareDelete(DeleteIsoCmd cmd);
+    TemplateProfile prepareDelete(DeleteTemplateCmd cmd);
 
-    public TemplateProfile prepareExtractTemplate(ExtractTemplateCmd cmd);
+    TemplateProfile prepareDelete(DeleteIsoCmd cmd);
 
-    public boolean delete(TemplateProfile profile);
+    TemplateProfile prepareExtractTemplate(ExtractTemplateCmd cmd);
 
-    public TemplateProfile prepare(boolean isIso, Long userId, String name, String displayText, Integer bits, Boolean passwordEnabled, Boolean requiresHVM, String url,
+    boolean delete(TemplateProfile profile);
+
+    TemplateProfile prepare(boolean isIso, Long userId, String name, String displayText, Integer bits, Boolean passwordEnabled, Boolean requiresHVM, String url,
         Boolean isPublic, Boolean featured, Boolean isExtractable, String format, Long guestOSId, List<Long> zoneId, HypervisorType hypervisorType, String accountName,
         Long domainId, String chksum, Boolean bootable, Map details, boolean directDownload) throws ResourceAllocationException;
 
-    public TemplateProfile prepare(boolean isIso, long userId, String name, String displayText, Integer bits, Boolean passwordEnabled, Boolean requiresHVM, String url,
+    TemplateProfile prepare(boolean isIso, long userId, String name, String displayText, Integer bits, Boolean passwordEnabled, Boolean requiresHVM, String url,
         Boolean isPublic, Boolean featured, Boolean isExtractable, String format, Long guestOSId, List<Long> zoneId, HypervisorType hypervisorType, String chksum,
         Boolean bootable, String templateTag, Account templateOwner, Map details, Boolean sshKeyEnabled, String imageStoreUuid, Boolean isDynamicallyScalable,
         TemplateType templateType, boolean directDownload) throws ResourceAllocationException;

--- a/ui/l10n/en.js
+++ b/ui/l10n/en.js
@@ -1721,6 +1721,7 @@ var dictionary = {
 "label.upgrade.router.newer.template":"Upgrade Router to Use Newer Template",
 "label.upload":"Upload",
 "label.upload.from.local":"Upload from Local",
+"label.upload.iso.from.local":"Upload ISO from Local",
 "label.upload.template.from.local":"Upload Template from Local",
 "label.upload.volume":"Upload volume",
 "label.upload.volume.from.local":"Upload Volume from Local",

--- a/ui/l10n/es.js
+++ b/ui/l10n/es.js
@@ -1666,6 +1666,7 @@ var dictionary = {
     "label.upgrade.router.newer.template": "Actualizar Router para usar una Plantilla más Nueva",
     "label.upload": "Subir",
     "label.upload.from.local": "Subir desde Local",
+    "label.upload.iso.from.local":"Subir ISO desde Local",
     "label.upload.template.from.local": "Subir Plantilla desde Local",
     "label.upload.volume": "Subir volumen",
     "label.upload.volume.from.local": "Subir un Volumen desde Local",

--- a/ui/scripts/templates.js
+++ b/ui/scripts/templates.js
@@ -2328,6 +2328,180 @@
                                     args.complete();
                                 }
                             }
+                        },
+                        uploadISOFromLocal: {
+                            isHeader: true,
+                            label: 'label.upload.from.local',
+                            messages: {
+                                notification: function(args) {
+                                    return 'label.upload.iso.from.local';
+                                }
+                            },
+                            createForm: {
+                                title: 'label.upload.iso.from.local',
+                                preFilter: cloudStack.preFilter.createTemplate,
+                                fileUpload: {
+                                    getURL: function(args) {
+                                        args.data = args.formData;
+
+                                        var data = {
+                                            name: args.data.name,
+                                            displayText: args.data.description,
+                                            zoneid: args.data.zone,
+                                            format: "ISO",
+                                            isextractable: (args.data.isExtractable == "on"),
+                                            bootable: (args.data.isBootable == "on"),
+                                            ispublic: (args.data.isPublic == "on"),
+                                            isfeatured: (args.data.isFeatured == "on")
+                                        };
+
+                                        if (args.$form.find('.form-item[rel=osTypeId]').is(':visible')) {
+                                            $.extend(data, {
+                                                osTypeId: args.data.osTypeId,
+                                            });
+                                        }
+
+                                        $.ajax({
+                                            url: createURL('getUploadParamsForIso'),
+                                            data: data,
+                                            async: false,
+                                            success: function(json) {
+                                                var uploadparams = json.postuploadisoresponse.getuploadparams;
+                                                var templateId = uploadparams.id;
+
+                                                args.response.success({
+                                                    url: uploadparams.postURL,
+                                                    ajaxPost: true,
+                                                    data: {
+                                                        'X-signature': uploadparams.signature,
+                                                        'X-expires': uploadparams.expires,
+                                                        'X-metadata': uploadparams.metadata
+                                                    }
+                                                });
+                                            }
+                                        });
+                                    },
+                                    postUpload: function(args) {
+                                        if(args.error) {
+                                            args.response.error(args.errorMsg);
+                                        } else {
+                                            cloudStack.dialog.notice({
+                                                message: "This ISO file has been uploaded. Please check its status at Templates menu > " + args.data.name + " > Zones tab > click a zone > Status field and Ready field."
+                                            });
+                                            args.response.success();
+                                        }
+                                    }
+                                },
+                                fields: {
+                                    templateFileUpload: {
+                                        label: 'label.local.file',
+                                        isFileUpload: true,
+                                        validation: {
+                                            required: true
+                                        }
+                                    },
+                                    name: {
+                                        label: 'label.name',
+                                        docID: 'helpRegisterISOName',
+                                        validation: {
+                                            required: true
+                                        }
+                                    },
+                                    description: {
+                                        label: 'label.description',
+                                        docID: 'helpRegisterISODescription',
+                                        validation: {
+                                            required: true
+                                        }
+                                    },
+
+                                    zone: {
+                                        label: 'label.zone',
+                                        docID: 'helpRegisterISOZone',
+                                        select: function(args) {
+                                            $.ajax({
+                                                url: createURL("listZones&available=true"),
+                                                dataType: "json",
+                                                async: true,
+                                                success: function(json) {
+                                                    var zoneObjs = json.listzonesresponse.zone;
+                                                    args.response.success({
+                                                        descriptionField: 'name',
+                                                        data: zoneObjs
+                                                    });
+                                                }
+                                            });
+                                        }
+                                    },
+
+                                    isBootable: {
+                                        label: "label.bootable",
+                                        docID: 'helpRegisterISOBootable',
+                                        isBoolean: true,
+                                        isChecked: true
+                                    },
+
+                                    osTypeId: {
+                                        label: 'label.os.type',
+                                        docID: 'helpRegisterISOOSType',
+                                        dependsOn: 'isBootable',
+                                        isHidden: false,
+                                        validation: {
+                                            required: true
+                                        },
+                                        select: function(args) {
+                                            $.ajax({
+                                                url: createURL("listOsTypes"),
+                                                dataType: "json",
+                                                async: true,
+                                                success: function(json) {
+                                                    var ostypeObjs = json.listostypesresponse.ostype;
+                                                    var items = [];
+                                                    $(ostypeObjs).each(function() {
+                                                        items.push({
+                                                            id: this.id,
+                                                            description: this.description
+                                                        });
+                                                    });
+                                                    args.response.success({
+                                                        data: items
+                                                    });
+                                                }
+                                            });
+                                        }
+                                    },
+
+                                    isExtractable: {
+                                        label: "label.extractable",
+                                        docID: 'helpRegisterISOExtractable',
+                                        isBoolean: true
+                                    },
+
+                                    isPublic: {
+                                        label: "label.public",
+                                        docID: 'helpRegisterISOPublic',
+                                        isBoolean: true,
+                                        isHidden: true
+                                    },
+
+                                    isFeatured: {
+                                        label: "label.featured",
+                                        docID: 'helpRegisterISOFeatured',
+                                        isBoolean: true,
+                                        isHidden: true
+                                    }
+                                }
+                            },
+
+                            action: function(args) {
+                                return;
+                            },
+
+                            notification: {
+                                poll: function(args) {
+                                    args.complete();
+                                }
+                            }
                         }
                     },
 


### PR DESCRIPTION
## Description
**Problem:** Users can register ISOs from URL but cannot upload local ISOs.

**Root cause:** CloudStack provides browser-based upload support for volumes and templates, but ISOs are not supported.

**Solution:** 
The existing browser-based upload from local functionality for templates and volumes (https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=39620237) is extended to support uploading local ISOs. 
- Extend the UI: A new button is created under the ISOs view: 'Upload from Local'. A new dialog form is displayed in which the user must select the ISO to upload from its local file system.
- Extend the API: New 'GetUploadParamsForIso' API command is created to handle the ISO upload.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5295080/54279039-cd08b900-4572-11e9-9720-df874eca5d6c.png)
![image](https://user-images.githubusercontent.com/5295080/54279077-e9a4f100-4572-11e9-843d-e616058e4895.png)


## How Has This Been Tested?
Templates tab -> ISOs -> Upload from local -> Select file on local file system
