### PR TITLE
api: snapshot, snapshotpolicy tag support

### DIFF
--- a/api/src/main/java/com/cloud/server/ResourceTag.java
+++ b/api/src/main/java/com/cloud/server/ResourceTag.java
@@ -58,7 +58,7 @@ public interface ResourceTag extends ControlledEntity, Identity, InternalIdentit
         AutoScaleVmGroup(false, true),
         LBStickinessPolicy(false, true),
         LBHealthCheckPolicy(false, true),
-        SnapshotPolicy(false, true),
+        SnapshotPolicy(true, true),
         GuestOs(false, true),
         NetworkOffering(false, true),
         VpcOffering(true, false);

--- a/api/src/main/java/com/cloud/storage/VolumeApiService.java
+++ b/api/src/main/java/com/cloud/storage/VolumeApiService.java
@@ -19,6 +19,7 @@
 package com.cloud.storage;
 
 import java.net.MalformedURLException;
+import java.util.Map;
 
 import org.apache.cloudstack.api.command.user.volume.AttachVolumeCmd;
 import org.apache.cloudstack.api.command.user.volume.CreateVolumeCmd;
@@ -93,7 +94,7 @@ public interface VolumeApiService {
 
     Volume detachVolumeFromVM(DetachVolumeCmd cmd);
 
-    Snapshot takeSnapshot(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm, Snapshot.LocationType locationType, boolean asyncBackup)
+    Snapshot takeSnapshot(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm, Snapshot.LocationType locationType, boolean asyncBackup, Map<String, String> tags)
             throws ResourceAllocationException;
 
     Snapshot allocSnapshot(Long volumeId, Long policyId, String snapshotName, Snapshot.LocationType locationType) throws ResourceAllocationException;

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/CreateSnapshotPolicyCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/snapshot/CreateSnapshotPolicyCmd.java
@@ -16,9 +16,11 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.snapshot;
 
-import org.apache.cloudstack.acl.RoleType;
-import org.apache.log4j.Logger;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -27,6 +29,8 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.SnapshotPolicyResponse;
 import org.apache.cloudstack.api.response.VolumeResponse;
+import org.apache.commons.collections.MapUtils;
+import org.apache.log4j.Logger;
 
 import com.cloud.exception.InvalidParameterValueException;
 import com.cloud.exception.PermissionDeniedException;
@@ -67,6 +71,9 @@ public class CreateSnapshotPolicyCmd extends BaseCmd {
 
     @Parameter(name = ApiConstants.FOR_DISPLAY, type = CommandType.BOOLEAN, description = "an optional field, whether to the display the policy to the end user or not", since = "4.4", authorized = {RoleType.Admin})
     private Boolean display;
+
+    @Parameter(name = ApiConstants.TAGS, type = CommandType.MAP, description = "Map of tags (key/value pairs)")
+    private Map tags;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
@@ -131,6 +138,18 @@ public class CreateSnapshotPolicyCmd extends BaseCmd {
         }
 
         return volume.getAccountId();
+    }
+
+    public Map<String, String> getTags() {
+        Map<String, String> tagsMap = new HashMap<>();
+        if (MapUtils.isNotEmpty(tags)) {
+            for (Map<String, String> services : (Collection<Map<String, String>>)tags.values()) {
+                String key = services.get("key");
+                String value = services.get("value");
+                tagsMap.put(key, value);
+            }
+        }
+        return tagsMap;
     }
 
     @Override

--- a/api/src/main/java/org/apache/cloudstack/api/response/SnapshotPolicyResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SnapshotPolicyResponse.java
@@ -16,18 +16,20 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
-import com.google.gson.annotations.SerializedName;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseResponse;
+import org.apache.cloudstack.api.BaseResponseWithTagInformation;
 import org.apache.cloudstack.api.EntityReference;
 
 import com.cloud.serializer.Param;
 import com.cloud.storage.snapshot.SnapshotPolicy;
+import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = SnapshotPolicy.class)
-public class SnapshotPolicyResponse extends BaseResponse {
+public class SnapshotPolicyResponse extends BaseResponseWithTagInformation {
     @SerializedName("id")
     @Param(description = "the ID of the snapshot policy")
     private String id;
@@ -55,6 +57,10 @@ public class SnapshotPolicyResponse extends BaseResponse {
     @SerializedName(ApiConstants.FOR_DISPLAY)
     @Param(description = "is this policy for display to the regular user", since = "4.4", authorized = {RoleType.Admin})
     private Boolean forDisplay;
+
+    public SnapshotPolicyResponse() {
+        tags = new LinkedHashSet<ResourceTagResponse>();
+    }
 
     public String getId() {
         return id;
@@ -110,5 +116,9 @@ public class SnapshotPolicyResponse extends BaseResponse {
 
     public void setForDisplay(Boolean forDisplay) {
         this.forDisplay = forDisplay;
+    }
+
+    public void setTags(Set<ResourceTagResponse> tags) {
+        this.tags = tags;
     }
 }

--- a/api/src/main/java/org/apache/cloudstack/api/response/SnapshotResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/SnapshotResponse.java
@@ -16,18 +16,20 @@
 // under the License.
 package org.apache.cloudstack.api.response;
 
+import java.util.Date;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseResponseWithTagInformation;
+import org.apache.cloudstack.api.EntityReference;
+
 import com.cloud.serializer.Param;
 import com.cloud.storage.Snapshot;
 import com.google.gson.annotations.SerializedName;
-import org.apache.cloudstack.api.ApiConstants;
-import org.apache.cloudstack.api.BaseResponse;
-import org.apache.cloudstack.api.EntityReference;
-
-import java.util.Date;
-import java.util.List;
 
 @EntityReference(value = Snapshot.class)
-public class SnapshotResponse extends BaseResponse implements ControlledEntityResponse {
+public class SnapshotResponse extends BaseResponseWithTagInformation implements ControlledEntityResponse {
     @SerializedName(ApiConstants.ID)
     @Param(description = "ID of the snapshot")
     private String id;
@@ -96,10 +98,6 @@ public class SnapshotResponse extends BaseResponse implements ControlledEntityRe
     @Param(description = "id of the availability zone")
     private String zoneId;
 
-    @SerializedName(ApiConstants.TAGS)
-    @Param(description = "the list of resource tags associated with snapshot", responseObject = ResourceTagResponse.class)
-    private List<ResourceTagResponse> tags;
-
     @SerializedName(ApiConstants.REVERTABLE)
     @Param(description = "indicates whether the underlying storage supports reverting the volume to this snapshot")
     private boolean revertable;
@@ -115,6 +113,10 @@ public class SnapshotResponse extends BaseResponse implements ControlledEntityRe
     @SerializedName(ApiConstants.VIRTUAL_SIZE)
     @Param(description = "virtual size of backedup snapshot on image store")
     private long virtualSize;
+
+    public SnapshotResponse() {
+        tags = new LinkedHashSet<ResourceTagResponse>();
+    }
 
     @Override
     public String getObjectId() {
@@ -206,7 +208,7 @@ public class SnapshotResponse extends BaseResponse implements ControlledEntityRe
         this.zoneId = zoneId;
     }
 
-    public void setTags(List<ResourceTagResponse> tags) {
+    public void setTags(Set<ResourceTagResponse> tags) {
         this.tags = tags;
     }
 

--- a/api/src/test/java/org/apache/cloudstack/api/command/test/CreateSnapshotCmdTest.java
+++ b/api/src/test/java/org/apache/cloudstack/api/command/test/CreateSnapshotCmdTest.java
@@ -16,11 +16,16 @@
 // under the License.
 package org.apache.cloudstack.api.command.test;
 
-import com.cloud.storage.Snapshot;
-import com.cloud.storage.VolumeApiService;
-import com.cloud.user.Account;
-import com.cloud.user.AccountService;
-import junit.framework.TestCase;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.cloudstack.api.ResponseGenerator;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotCmd;
@@ -31,12 +36,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
+import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.isNull;
+import com.cloud.storage.Snapshot;
+import com.cloud.storage.VolumeApiService;
+import com.cloud.user.Account;
+import com.cloud.user.AccountService;
+
+import junit.framework.TestCase;
 
 public class CreateSnapshotCmdTest extends TestCase {
 
@@ -80,9 +87,8 @@ public class CreateSnapshotCmdTest extends TestCase {
         VolumeApiService volumeApiService = Mockito.mock(VolumeApiService.class);
         Snapshot snapshot = Mockito.mock(Snapshot.class);
         try {
-
             Mockito.when(volumeApiService.takeSnapshot(anyLong(), anyLong(), anyLong(),
-                    any(Account.class), anyBoolean(), isNull(Snapshot.LocationType.class), anyBoolean())).thenReturn(snapshot);
+                    any(Account.class), anyBoolean(), isNull(Snapshot.LocationType.class), anyBoolean(), anyObject())).thenReturn(snapshot);
 
         } catch (Exception e) {
             Assert.fail("Received exception when success expected " + e.getMessage());
@@ -115,7 +121,7 @@ public class CreateSnapshotCmdTest extends TestCase {
 
         try {
                 Mockito.when(volumeApiService.takeSnapshot(anyLong(), anyLong(), anyLong(),
-                        any(Account.class), anyBoolean(), isNull(Snapshot.LocationType.class), anyBoolean())).thenReturn(null);
+                        any(Account.class), anyBoolean(), isNull(Snapshot.LocationType.class), anyBoolean(), anyObject())).thenReturn(null);
         } catch (Exception e) {
             Assert.fail("Received exception when success expected " + e.getMessage());
         }
@@ -128,5 +134,25 @@ public class CreateSnapshotCmdTest extends TestCase {
         } catch (ServerApiException exception) {
             Assert.assertEquals("Failed to create snapshot due to an internal error creating snapshot for volume 1", exception.getDescription());
         }
+    }
+
+    @Test
+    public void testParsingTags() {
+        final CreateSnapshotCmd createSnapshotCmd = new CreateSnapshotCmd();
+        final Map<String, String> tag1 = new HashMap<>();
+        tag1.put("key", "key1");
+        tag1.put("value", "value1");
+        final Map<String, String> tag2 = new HashMap<>();
+        tag2.put("key", "key2");
+        tag2.put("value", "value2");
+        final Map<String, String> expectedTags = new HashMap<>();
+        expectedTags.put("key1", "value1");
+        expectedTags.put("key2", "value2");
+
+        final Map<String, Map<String, String>> tagsParams = new HashMap<>();
+        tagsParams.put("0", tag1);
+        tagsParams.put("1", tag2);
+        ReflectionTestUtils.setField(createSnapshotCmd, "tags", tagsParams);
+        Assert.assertEquals(createSnapshotCmd.getTags(), expectedTags);
     }
 }

--- a/server/src/main/java/com/cloud/api/ApiResponseHelper.java
+++ b/server/src/main/java/com/cloud/api/ApiResponseHelper.java
@@ -546,7 +546,7 @@ public class ApiResponseHelper implements ResponseGenerator {
             ResourceTagResponse tagResponse = createResourceTagResponse(tag, true);
             CollectionUtils.addIgnoreNull(tagResponses, tagResponse);
         }
-        snapshotResponse.setTags(tagResponses);
+        snapshotResponse.setTags(new HashSet<>(tagResponses));
 
         snapshotResponse.setObjectName("snapshot");
         return snapshotResponse;
@@ -639,6 +639,14 @@ public class ApiResponseHelper implements ResponseGenerator {
         policyResponse.setTimezone(policy.getTimezone());
         policyResponse.setForDisplay(policy.isDisplay());
         policyResponse.setObjectName("snapshotpolicy");
+
+        List<? extends ResourceTag> tags = _resourceTagDao.listBy(policy.getId(), ResourceObjectType.SnapshotPolicy);
+        List<ResourceTagResponse> tagResponses = new ArrayList<ResourceTagResponse>();
+        for (ResourceTag tag : tags) {
+            ResourceTagResponse tagResponse = createResourceTagResponse(tag, false);
+            CollectionUtils.addIgnoreNull(tagResponses, tagResponse);
+        }
+        policyResponse.setTags(new HashSet<>(tagResponses));
 
         return policyResponse;
     }

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -82,6 +82,7 @@ import org.apache.cloudstack.utils.identity.ManagementServerNode;
 import org.apache.cloudstack.utils.imagestore.ImageStoreUtil;
 import org.apache.cloudstack.utils.volume.VirtualMachineDiskInfo;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
 import org.apache.log4j.Logger;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -116,6 +117,8 @@ import com.cloud.hypervisor.HypervisorCapabilitiesVO;
 import com.cloud.hypervisor.dao.HypervisorCapabilitiesDao;
 import com.cloud.org.Grouping;
 import com.cloud.serializer.GsonHelper;
+import com.cloud.server.ResourceTag;
+import com.cloud.server.TaggedResourceService;
 import com.cloud.service.dao.ServiceOfferingDetailsDao;
 import com.cloud.storage.Storage.ImageFormat;
 import com.cloud.storage.dao.DiskOfferingDao;
@@ -257,6 +260,8 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
     private StoragePoolDetailsDao storagePoolDetailsDao;
     @Inject
     private StorageUtil storageUtil;
+    @Inject
+    public TaggedResourceService taggedResourceService;
 
     protected Gson _gson;
 
@@ -2329,7 +2334,16 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
 
     @Override
     @ActionEvent(eventType = EventTypes.EVENT_SNAPSHOT_CREATE, eventDescription = "taking snapshot", async = true)
-    public Snapshot takeSnapshot(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm, Snapshot.LocationType locationType, boolean asyncBackup)
+    public Snapshot takeSnapshot(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm, Snapshot.LocationType locationType, boolean asyncBackup, Map<String, String> tags)
+            throws ResourceAllocationException {
+        final Snapshot snapshot = takeSnapshotInternal(volumeId, policyId, snapshotId, account, quiescevm, locationType, asyncBackup);
+        if (snapshot != null && MapUtils.isNotEmpty(tags)) {
+            taggedResourceService.createTags(Collections.singletonList(snapshot.getUuid()), ResourceTag.ResourceObjectType.Snapshot, tags, null);
+        }
+        return snapshot;
+    }
+
+    private Snapshot takeSnapshotInternal(Long volumeId, Long policyId, Long snapshotId, Account account, boolean quiescevm, Snapshot.LocationType locationType, boolean asyncBackup)
             throws ResourceAllocationException {
         VolumeInfo volume = volFactory.getVolume(volumeId);
         if (volume == null) {

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotManagerImpl.java
@@ -16,8 +16,53 @@
 // under the License.
 package com.cloud.storage.snapshot;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Inject;
+import javax.naming.ConfigurationException;
+
+import org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotPolicyCmd;
+import org.apache.cloudstack.api.command.user.snapshot.DeleteSnapshotPoliciesCmd;
+import org.apache.cloudstack.api.command.user.snapshot.ListSnapshotPoliciesCmd;
+import org.apache.cloudstack.api.command.user.snapshot.ListSnapshotsCmd;
+import org.apache.cloudstack.api.command.user.snapshot.UpdateSnapshotPolicyCmd;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreCapabilities;
+import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
+import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
+import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
+import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotService;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotStrategy;
+import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotStrategy.SnapshotOperation;
+import org.apache.cloudstack.engine.subsystem.api.storage.StorageStrategyFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
+import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
+import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
+import org.apache.cloudstack.framework.config.ConfigKey;
+import org.apache.cloudstack.framework.config.Configurable;
+import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
+import org.apache.cloudstack.managed.context.ManagedContextRunnable;
+import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
+import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
+import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
+import org.apache.commons.collections.MapUtils;
+import org.apache.log4j.Logger;
+import org.springframework.stereotype.Component;
+
 import com.cloud.agent.api.Answer;
-import com.cloud.utils.db.GlobalLock;
 import com.cloud.agent.api.Command;
 import com.cloud.agent.api.DeleteSnapshotsDirCommand;
 import com.cloud.alert.AlertManager;
@@ -42,6 +87,7 @@ import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.projects.Project.ListProjectResourcesCriteria;
 import com.cloud.resource.ResourceManager;
 import com.cloud.server.ResourceTag.ResourceObjectType;
+import com.cloud.server.TaggedResourceService;
 import com.cloud.storage.CreateSnapshotPayload;
 import com.cloud.storage.DataStoreRole;
 import com.cloud.storage.ScopeType;
@@ -80,6 +126,7 @@ import com.cloud.utils.Ternary;
 import com.cloud.utils.concurrency.NamedThreadFactory;
 import com.cloud.utils.db.DB;
 import com.cloud.utils.db.Filter;
+import com.cloud.utils.db.GlobalLock;
 import com.cloud.utils.db.JoinBuilder;
 import com.cloud.utils.db.SearchBuilder;
 import com.cloud.utils.db.SearchCriteria;
@@ -92,48 +139,6 @@ import com.cloud.vm.dao.UserVmDao;
 import com.cloud.vm.snapshot.VMSnapshot;
 import com.cloud.vm.snapshot.VMSnapshotVO;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
-import org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotPolicyCmd;
-import org.apache.cloudstack.api.command.user.snapshot.DeleteSnapshotPoliciesCmd;
-import org.apache.cloudstack.api.command.user.snapshot.ListSnapshotPoliciesCmd;
-import org.apache.cloudstack.api.command.user.snapshot.ListSnapshotsCmd;
-import org.apache.cloudstack.api.command.user.snapshot.UpdateSnapshotPolicyCmd;
-import org.apache.cloudstack.context.CallContext;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStore;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreCapabilities;
-import org.apache.cloudstack.engine.subsystem.api.storage.DataStoreManager;
-import org.apache.cloudstack.engine.subsystem.api.storage.EndPoint;
-import org.apache.cloudstack.engine.subsystem.api.storage.EndPointSelector;
-import org.apache.cloudstack.engine.subsystem.api.storage.ObjectInDataStoreStateMachine;
-import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotDataFactory;
-import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotInfo;
-import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotService;
-import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotStrategy;
-import org.apache.cloudstack.engine.subsystem.api.storage.SnapshotStrategy.SnapshotOperation;
-import org.apache.cloudstack.engine.subsystem.api.storage.StorageStrategyFactory;
-import org.apache.cloudstack.engine.subsystem.api.storage.VolumeDataFactory;
-import org.apache.cloudstack.engine.subsystem.api.storage.VolumeInfo;
-import org.apache.cloudstack.engine.subsystem.api.storage.ZoneScope;
-import org.apache.cloudstack.framework.config.ConfigKey;
-import org.apache.cloudstack.framework.config.Configurable;
-import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
-import org.apache.cloudstack.managed.context.ManagedContextRunnable;
-import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
-import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreDao;
-import org.apache.cloudstack.storage.datastore.db.SnapshotDataStoreVO;
-import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
-import org.apache.log4j.Logger;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
-import javax.naming.ConfigurationException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 
 @Component
 public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implements SnapshotManager, SnapshotApiService, Configurable {
@@ -192,6 +197,8 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
     ResourceManager _resourceMgr;
     @Inject
     StorageStrategyFactory _storageStrategyFactory;
+    @Inject
+    public TaggedResourceService taggedResourceService;
 
     private int _totalRetries;
     private int _pauseInterval;
@@ -902,6 +909,11 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
                     policy.setDisplay(display);
                     _snapshotPolicyDao.update(policy.getId(), policy);
                     _snapSchedMgr.scheduleOrCancelNextSnapshotJobOnDisplayChange(policy, previousDisplay);
+                    taggedResourceService.deleteTags(Collections.singletonList(policy.getUuid()), ResourceObjectType.SnapshotPolicy, null);
+                }
+                final Map<String, String> tags = cmd.getTags();
+                if (MapUtils.isNotEmpty(tags)) {
+                    taggedResourceService.createTags(Collections.singletonList(policy.getUuid()), ResourceObjectType.SnapshotPolicy, tags, null);
                 }
             } finally {
                 createSnapshotPolicyLock.unlock();
@@ -916,10 +928,13 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         }
     }
 
-    protected boolean deletePolicy(long userId, Long policyId) {
+    protected boolean deletePolicy(Long policyId) {
         SnapshotPolicyVO snapshotPolicy = _snapshotPolicyDao.findById(policyId);
         _snapSchedMgr.removeSchedule(snapshotPolicy.getVolumeId(), snapshotPolicy.getId());
-        return _snapshotPolicyDao.remove(policyId);
+        if (taggedResourceService.deleteTags(Collections.singletonList(snapshotPolicy.getUuid()), ResourceObjectType.SnapshotPolicy, null)) {
+            return _snapshotPolicyDao.remove(policyId);
+        }
+        throw new CloudRuntimeException("Unable to delete snapshot policy due to failure to delete tags for the snapshot policy uuid: " + snapshotPolicy.getUuid());
     }
 
     @Override
@@ -963,8 +978,7 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
     public void deletePoliciesForVolume(Long volumeId) {
         List<SnapshotPolicyVO> policyInstances = listPoliciesforVolume(volumeId);
         for (SnapshotPolicyVO policyInstance : policyInstances) {
-            Long policyId = policyInstance.getId();
-            deletePolicy(1L, policyId);
+            deletePolicy(policyInstance.getId());
         }
         // We also want to delete the manual snapshots scheduled for this volume
         // We can only delete the schedules in the future, not the ones which are already executing.
@@ -1321,7 +1335,6 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
     public boolean deleteSnapshotPolicies(DeleteSnapshotPoliciesCmd cmd) {
         Long policyId = cmd.getId();
         List<Long> policyIds = cmd.getIds();
-        Long userId = getSnapshotUserId();
 
         if ((policyId == null) && (policyIds == null)) {
             throw new InvalidParameterValueException("No policy id (or list of ids) specified.");
@@ -1333,6 +1346,10 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
         } else if (policyIds.size() <= 0) {
             // Not even sure how this is even possible
             throw new InvalidParameterValueException("There are no policy ids");
+        }
+
+        if (policyIds.contains(Snapshot.MANUAL_POLICY_ID)) {
+            throw new InvalidParameterValueException("Invalid Policy id given: " + Snapshot.MANUAL_POLICY_ID);
         }
 
         for (Long policy : policyIds) {
@@ -1348,21 +1365,14 @@ public class SnapshotManagerImpl extends MutualExclusiveIdsManagerBase implement
             _accountMgr.checkAccess(CallContext.current().getCallingAccount(), null, true, volume);
         }
 
-        boolean success = true;
-
-        if (policyIds.contains(Snapshot.MANUAL_POLICY_ID)) {
-            throw new InvalidParameterValueException("Invalid Policy id given: " + Snapshot.MANUAL_POLICY_ID);
-        }
-
         for (Long pId : policyIds) {
-            if (!deletePolicy(userId, pId)) {
-                success = false;
+            if (!deletePolicy(pId)) {
                 s_logger.warn("Failed to delete snapshot policy with Id: " + policyId);
-                return success;
+                return false;
             }
         }
 
-        return success;
+        return true;
     }
 
     @Override

--- a/server/src/main/java/com/cloud/storage/snapshot/SnapshotSchedulerImpl.java
+++ b/server/src/main/java/com/cloud/storage/snapshot/SnapshotSchedulerImpl.java
@@ -43,6 +43,8 @@ import com.cloud.api.ApiDispatcher;
 import com.cloud.api.ApiGsonHelper;
 import com.cloud.event.ActionEventUtils;
 import com.cloud.event.EventTypes;
+import com.cloud.server.ResourceTag;
+import com.cloud.server.TaggedResourceService;
 import com.cloud.storage.Snapshot;
 import com.cloud.storage.SnapshotPolicyVO;
 import com.cloud.storage.SnapshotScheduleVO;
@@ -97,6 +99,8 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
     protected VMSnapshotDao _vmSnapshotDao;
     @Inject
     protected VMSnapshotManager _vmSnaphostManager;
+    @Inject
+    public TaggedResourceService taggedResourceService;
 
     protected AsyncJobDispatcher _asyncDispatcher;
 
@@ -305,6 +309,15 @@ public class SnapshotSchedulerImpl extends ManagerBase implements SnapshotSchedu
                 params.put("ctxUserId", "1");
                 params.put("ctxAccountId", "" + volume.getAccountId());
                 params.put("ctxStartEventId", String.valueOf(eventId));
+                List<? extends ResourceTag> resourceTags = taggedResourceService.listByResourceTypeAndId(ResourceTag.ResourceObjectType.SnapshotPolicy, policyId);
+                if (resourceTags != null && !resourceTags.isEmpty()) {
+                    int tagNumber = 0;
+                    for (ResourceTag resourceTag : resourceTags) {
+                        params.put("tags[" + tagNumber + "].key", resourceTag.getKey());
+                        params.put("tags[" + tagNumber + "].value", resourceTag.getValue());
+                        tagNumber++;
+                    }
+                }
 
                 final CreateSnapshotCmd cmd = new CreateSnapshotCmd();
                 ComponentContext.inject(cmd);

--- a/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
+++ b/server/src/test/java/com/cloud/storage/VolumeApiServiceImplTest.java
@@ -18,6 +18,7 @@ package com.cloud.storage;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
@@ -67,6 +68,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.cloud.configuration.Resource;
 import com.cloud.configuration.Resource.ResourceType;
@@ -78,6 +80,7 @@ import com.cloud.host.dao.HostDao;
 import com.cloud.hypervisor.Hypervisor.HypervisorType;
 import com.cloud.org.Grouping;
 import com.cloud.serializer.GsonHelper;
+import com.cloud.server.TaggedResourceService;
 import com.cloud.storage.Volume.Type;
 import com.cloud.storage.dao.VolumeDao;
 import com.cloud.storage.snapshot.SnapshotManager;
@@ -410,7 +413,7 @@ public class VolumeApiServiceImplTest {
         when(volumeDataFactoryMock.getVolume(anyLong())).thenReturn(volumeInfoMock);
         when(volumeInfoMock.getState()).thenReturn(Volume.State.Allocated);
         when(volumeInfoMock.getPoolId()).thenReturn(1L);
-        volumeApiServiceImpl.takeSnapshot(5L, Snapshot.MANUAL_POLICY_ID, 3L, null, false, null, false);
+        volumeApiServiceImpl.takeSnapshot(5L, Snapshot.MANUAL_POLICY_ID, 3L, null, false, null, false, null);
     }
 
     @Test
@@ -420,7 +423,10 @@ public class VolumeApiServiceImplTest {
         when(volumeInfoMock.getInstanceId()).thenReturn(null);
         when(volumeInfoMock.getPoolId()).thenReturn(1L);
         when(volumeServiceMock.takeSnapshot(Mockito.any(VolumeInfo.class))).thenReturn(snapshotInfoMock);
-        volumeApiServiceImpl.takeSnapshot(5L, Snapshot.MANUAL_POLICY_ID, 3L, null, false, null, false);
+        final TaggedResourceService taggedResourceService = Mockito.mock(TaggedResourceService.class);
+        Mockito.when(taggedResourceService.createTags(anyObject(), anyObject(), anyObject(), anyObject())).thenReturn(null);
+        ReflectionTestUtils.setField(volumeApiServiceImpl, "taggedResourceService", taggedResourceService);
+        volumeApiServiceImpl.takeSnapshot(5L, Snapshot.MANUAL_POLICY_ID, 3L, null, false, null, false, null);
     }
 
     @Test

--- a/ui/css/cloudstack3.css
+++ b/ui/css/cloudstack3.css
@@ -4179,7 +4179,7 @@ textarea {
   float: left;
 }
 
-.ui-dialog div.form-container div.value label {
+#label_delete_volumes label {
   display: block;
   width: 119px;
   text-align: left;
@@ -8782,6 +8782,11 @@ div#details-tab-aclRules td.cidrlist span {
   top: 4px;
 }
 
+.recurring-snapshots .schedule .forms .tagger form div.value label {
+  width: 25px;
+  top: 10px;
+}
+
 .recurring-snapshots .schedule .forms form label.error {
   width: 100%;
   float: left;
@@ -8792,6 +8797,10 @@ div#details-tab-aclRules td.cidrlist span {
   width: 100%;
   float: left;
   margin: 8px 0 0;
+}
+
+.recurring-snapshots .schedule .forms .tagger form .field {
+  margin: 0;
 }
 
 .recurring-snapshots .schedule .forms form .name {
@@ -8936,6 +8945,11 @@ div#details-tab-aclRules td.cidrlist span {
   padding: 0;
   margin: 0;
   display: block;
+}
+
+.recurring-snapshots .ui-tabs .tagger ul {
+    margin: 16px auto auto;
+    padding-bottom: 10px;
 }
 
 .recurring-snapshots .ui-tabs ul li a {
@@ -11036,6 +11050,11 @@ div#details-tab-aclRules td.cidrlist span {
 
 .ui-dialog .tagger .tag-info {
   display: none;
+}
+
+.ui-dialog .tagger .tag-info.inside-form {
+  display: block;
+  text-align: left;
 }
 
 .ui-dialog.editTags .ui-button {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1562,6 +1562,9 @@
                                         <label for="maxsnaps"><translate key="label.snapshots" /></label>
                                     </div>
                                 </div>
+
+                                <!-- Tags -->
+                                <div class="field taggerContainer"></div>
                             </form>
                         </div>
 
@@ -1596,6 +1599,9 @@
                                         <label for="maxsnaps"><translate key="label.snapshots" /></label>
                                     </div>
                                 </div>
+
+                                <!-- Tags -->
+                                <div class="field taggerContainer"></div>
                             </form>
                         </div>
 
@@ -1638,6 +1644,9 @@
                                         <label for="maxsnaps"><translate key="label.snapshots" /></label>
                                     </div>
                                 </div>
+
+                                <!-- Tags -->
+                                <div class="field taggerContainer"></div>
                             </form>
                         </div>
 
@@ -1680,6 +1689,9 @@
                                         <label for="maxsnaps"><translate key="label.snapshots" /></label>
                                     </div>
                                 </div>
+
+                                <!-- Tags -->
+                                <div class="field taggerContainer"></div>
                             </form>
                         </div>
                     </div>

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -924,8 +924,12 @@
                                             label: 'label.name'
                                         },
                                         asyncBackup: {
-						label: 'label.async.backup',
-						isBoolean: true
+                                            label: 'label.async.backup',
+                                            isBoolean: true
+                                        },
+                                        tags: {
+                                            label: 'label.tags',
+                                            tagger: true
                                         }
                                     }
                                 },
@@ -940,6 +944,15 @@
                                             name: args.data.name
                                         });
                                     }
+                                    if (!$.isEmptyObject(args.data.tags)) {
+                                        $(args.data.tags).each(function(idx, tagData) {
+                                            var formattedTagData = {};
+                                            formattedTagData["tags[" + _s(idx) + "].key"] = _s(tagData.key);
+                                            formattedTagData["tags[" + _s(idx) + "].value"] = _s(tagData.value);
+                                            $.extend(data, formattedTagData);
+                                        });
+                                    }
+
                                     $.ajax({
                                         url: createURL("createSnapshot"),
                                         data: data,
@@ -998,7 +1011,9 @@
                                                 var snap = args.snapshot;
 
                                                 var data = {
-                                                    keep: snap.maxsnaps,
+                                                    volumeid: args.context.volumes[0].id,
+                                                    intervaltype: snap['snapshot-type'],
+                                                    maxsnaps: snap.maxsnaps,
                                                     timezone: snap.timezone
                                                 };
 
@@ -1051,15 +1066,18 @@
                                                         break;
                                                 }
 
+                                                if (!$.isEmptyObject(snap.tags)) {
+                                                    $(snap.tags).each(function(idx, tagData) {
+                                                        var formattedTagData = {};
+                                                        formattedTagData["tags[" + _s(idx) + "].key"] = _s(tagData.key);
+                                                        formattedTagData["tags[" + _s(idx) + "].value"] = _s(tagData.value);
+                                                        $.extend(data, formattedTagData);
+                                                    });
+                                                }
+
                                                 $.ajax({
                                                     url: createURL('createSnapshotPolicy'),
-                                                    data: {
-                                                        volumeid: args.context.volumes[0].id,
-                                                        intervaltype: snap['snapshot-type'],
-                                                        maxsnaps: snap.maxsnaps,
-                                                        schedule: data.schedule,
-                                                        timezone: snap.timezone
-                                                    },
+                                                    data: data,
                                                     dataType: 'json',
                                                     async: true,
                                                     success: function(successData) {

--- a/ui/scripts/ui-custom/recurringSnapshots.js
+++ b/ui/scripts/ui-custom/recurringSnapshots.js
@@ -61,6 +61,10 @@
                 }
             });
 
+            $($snapshots.find('.taggerContainer')).each(function() {
+                $('<div>').taggerInForm().appendTo(this);
+            });
+
             // Form validation
             $snapshots.find('form').validate();
 
@@ -70,7 +74,7 @@
 
                 if (!$form.valid()) return false;
 
-                var formData = cloudStack.serializeForm($form);
+                var formData = $.extend(cloudStack.serializeForm($form), {'tags' : cloudStack.getTagsFromForm($form)});
 
                 actions.add({
                     context: context,

--- a/ui/scripts/ui/dialog.js
+++ b/ui/scripts/ui/dialog.js
@@ -147,7 +147,6 @@
 
             var isAsync = false;
             var isNoDialog = args.noDialog ? args.noDialog : false;
-
             $(fields).each(function(idx, element) {
                 var key = this;
                 var field = args.form.fields[key];
@@ -188,7 +187,6 @@
                  closeOnEscape: false
                  }); */
                 // Label field
-
                 var $name = $('<div>').addClass('name')
                         .appendTo($formItem)
                         .append(
@@ -617,9 +615,9 @@
                     }
                     $input.addClass("disallowSpecialCharacters");
                     $input.datepicker({
-			dateFormat: 'yy-mm-dd',
-			maxDate: field.maxDate,
-			minDate: field.minDate
+                        dateFormat: 'yy-mm-dd',
+                        maxDate: field.maxDate,
+                        minDate: field.minDate
                     });
 
                 } else if (field.range) { //2 text fields on the same line (e.g. port range: startPort - endPort)
@@ -700,6 +698,10 @@
 
                         this.oldUnit = newUnit;
                     })
+                } else if (field.tagger) {
+                    $name.hide();
+                    $value.hide();
+                    $input = $('<div>').taggerInForm().appendTo($formItem);
                 } else { //text field
                     $input = $('<input>').attr({
                         name: key,
@@ -715,10 +717,12 @@
                     $input.addClass("disallowSpecialCharacters");
                 }
 
-                if (field.validation != null)
-                    $input.data('validation-rules', field.validation);
-                else
-                    $input.data('validation-rules', {});
+                if (!field.tagger) { // Tagger has it's own validation
+                    if (field.validation != null)
+                        $input.data('validation-rules', field.validation);
+                    else
+                        $input.data('validation-rules', {});
+                }
 
                 var fieldLabel = field.label;
 
@@ -772,7 +776,7 @@
 
             var complete = function($formContainer) {
                 var $form = $formContainer.find('form');
-                var data = cloudStack.serializeForm($form);
+                var data = $.extend(cloudStack.serializeForm($form), {'tags' : cloudStack.getTagsFromForm($form)});
 
                 if (!$formContainer.find('form').valid()) {
                     // Ignore hidden field validation


### PR DESCRIPTION
## Description
**Problem**: Currently tags cannot be applied to snapshot when it is being created but through separate “create tags” API calls. For snapshot policies tags cannot be set either at creation or through “create tags” API.

**Root Cause**: The “create snapshots” API does not support adding tags during creation and it can only be done through “create tags” API. Snapshot policy as a resource does not support tags and no tags can be set for them through any API.

**Solution**: Tag support for snapshot policy has been added. Snapshot policy with tags when executed will produce snapshots containing the same tags from snapshot policy.

Following APIs have been updated:
- Both “create snapshotpolicy” and “create snapshot” now accepts “tags” as a new parameter. The expected format for “tags” parameter is similar to parameter “tags” in “create tags“ API.
- Deletion support for tags associated with snapshots policy has been added to “delete snapshotpolicies” API.
- Tags set for snapshot policies are added to the Response of “list snapshotpolicies“ API.

UI support for setting tags to snapshots and snapshot policy is provided through the corresponding menus with a new section in each form to set tags.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)


## Screenshots (if appropriate):
![screenshot from 2019-02-08 13-39-23](https://user-images.githubusercontent.com/43956255/52466072-054d5e00-2ba7-11e9-9190-9d90fbdcd9ce.png)
![screenshot from 2019-02-08 13-38-53](https://user-images.githubusercontent.com/43956255/52466074-05e5f480-2ba7-11e9-9b43-08457fd4ff50.png)
![screenshot from 2019-02-08 13-25-35](https://user-images.githubusercontent.com/43956255/52466113-3037b200-2ba7-11e9-875d-7bc60399903c.png)

## How Has This Been Tested?
UI And Cloudmonkey.
```
(local) 🐵 > create snapshot volumeid=9d4a3e48-2c27-4822-98c0-a79381cf4113 tags[0].key=keyss tags[0].value=valuess
 
{
  "accountid": "77891a42-1e18-11e9-8d89-34e12d5f623e",
  "cmd": "org.apache.cloudstack.api.command.user.snapshot.CreateSnapshotCmd",
  "created": "2019-02-08T00:01:15+0530",
  "jobid": "f4b82b0d-f256-4c87-a8b4-36bbcb44cdeb",
  "jobinstanceid": "21086b5a-42da-4bd1-aa10-d7e62bed88a9",
  "jobinstancetype": "Snapshot",
  "jobprocstatus": 0,
  "jobresult": {
    "snapshot": {
      "account": "admin",
      "created": "2019-02-08T00:01:15+0530",
      "domain": "ROOT",
      "domainid": "77890928-1e18-11e9-8d89-34e12d5f623e",
      "id": "21086b5a-42da-4bd1-aa10-d7e62bed88a9",
      "intervaltype": "MANUAL",
      "name": "vm1_ROOT-6_20190207183115",
      "osdisplayname": "CentOS 5.5 (64-bit)",
      "ostypeid": "7780d0f5-1e18-11e9-8d89-34e12d5f623e",
      "physicalsize": 1596588032,
      "revertable": true,
      "snapshottype": "MANUAL",
      "state": "BackedUp",
      "tags": [
        {
          "key": "keyss",
          "value": "valuess"
        }
      ],
      "virtualsize": 8589934592,
      "volumeid": "9d4a3e48-2c27-4822-98c0-a79381cf4113",
      "volumename": "ROOT-6",
      "volumetype": "ROOT",
      "zoneid": "df67395c-d21d-4404-adcc-a44c9994763d"
    }
  },
  "jobresultcode": 0,
  "jobresulttype": "object",
  "jobstatus": 1,
  "userid": "77892e56-1e18-11e9-8d89-34e12d5f623e"
}
(local) 🐵 > create snapshotpolicy volumeid=9d4a3e48-2c27-4822-98c0-a79381cf4113 schedule=1 maxsnaps=1 intervaltype=HOURLY timezone="Etc/GMT+12" tags[0].key=hello tags[0].value=world
{
  "snapshotpolicy": {
    "fordisplay": true,
    "id": "c9da9363-cbab-47d8-8d1c-cbc69c140946",
    "intervaltype": 0,
    "maxsnaps": 1,
    "schedule": "1",
    "tags": [
      {
        "account": "system",
        "domain": "ROOT",
        "domainid": "77890928-1e18-11e9-8d89-34e12d5f623e",
        "key": "hello",
        "resourceid": "c9da9363-cbab-47d8-8d1c-cbc69c140946",
        "resourcetype": "SnapshotPolicy",
        "value": "world"
      }
    ],
    "timezone": "Etc/GMT+12",
    "volumeid": "9d4a3e48-2c27-4822-98c0-a79381cf4113"
  }
}
(local) 🐵 > list snapshotpolicies id=c9da9363-cbab-47d8-8d1c-cbc69c140946
{
  "count": 1,
  "snapshotpolicy": [
    {
      "fordisplay": true,
      "id": "c9da9363-cbab-47d8-8d1c-cbc69c140946",
      "intervaltype": 0,
      "maxsnaps": 1,
      "schedule": "1",
      "tags": [
        {
          "account": "system",
          "domain": "ROOT",
          "domainid": "77890928-1e18-11e9-8d89-34e12d5f623e",
          "key": "hello",
          "resourceid": "c9da9363-cbab-47d8-8d1c-cbc69c140946",
          "resourcetype": "SnapshotPolicy",
          "value": "world"
        }
      ],
      "timezone": "Etc/GMT+12",
      "volumeid": "9d4a3e48-2c27-4822-98c0-a79381cf4113"
    }
  ]
}


```
<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
