### PR TITLE
server: disk offerings for specified domain(s) and zone(s)

### DIFF
--- a/api/src/main/java/com/cloud/user/AccountService.java
+++ b/api/src/main/java/com/cloud/user/AccountService.java
@@ -25,6 +25,7 @@ import org.apache.cloudstack.api.command.admin.user.GetUserKeysCmd;
 import org.apache.cloudstack.api.command.admin.user.RegisterCmd;
 import org.apache.cloudstack.api.command.admin.user.UpdateUserCmd;
 
+import com.cloud.dc.DataCenter;
 import com.cloud.domain.Domain;
 import com.cloud.exception.PermissionDeniedException;
 import com.cloud.offering.DiskOffering;
@@ -98,7 +99,7 @@ public interface AccountService {
 
     void checkAccess(Account account, ServiceOffering so) throws PermissionDeniedException;
 
-    void checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException;
+    void checkAccess(Account account, DiskOffering dof, DataCenter zone) throws PermissionDeniedException;
 
     void checkAccess(User user, ControlledEntity entity);
 

--- a/api/src/main/java/org/apache/cloudstack/acl/SecurityChecker.java
+++ b/api/src/main/java/org/apache/cloudstack/acl/SecurityChecker.java
@@ -138,5 +138,5 @@ public interface SecurityChecker extends Adapter {
 
     public boolean checkAccess(Account account, ServiceOffering so) throws PermissionDeniedException;
 
-    boolean checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException;
+    boolean checkAccess(Account account, DiskOffering dof, DataCenter zone) throws PermissionDeniedException;
 }

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -706,6 +706,7 @@ public class ApiConstants {
     public static final String NETSCALER_SERVICEPACKAGE_ID = "netscalerservicepackageid";
 
     public static final String ZONE_ID_LIST = "zoneids";
+    public static final String ZONE_NAME_LIST = "zonenames";
     public static final String DESTINATION_ZONE_ID_LIST = "destzoneids";
     public static final String ADMIN = "admin";
     public static final String CHECKSUM_PARAMETER_PREFIX_DESCRIPTION = "The parameter containing the checksum will be considered a MD5sum if it is not prefixed\n"

--- a/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
+++ b/api/src/main/java/org/apache/cloudstack/api/ApiConstants.java
@@ -112,6 +112,8 @@ public class ApiConstants {
     public static final String DOMAIN = "domain";
     public static final String DOMAIN_ID = "domainid";
     public static final String DOMAIN__ID = "domainId";
+    public static final String DOMAIN_ID_LIST = "domainids";
+    public static final String DOMAIN_NAME_LIST = "domainnames";
     public static final String DURATION = "duration";
     public static final String ELIGIBLE = "eligible";
     public static final String EMAIL = "email";

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
@@ -66,12 +66,22 @@ public class CreateDiskOfferingCmd extends BaseCmd {
                description = "the ID of the containing domain, null for public offerings")
     private Long domainId;
 
+    @Parameter(name = ApiConstants.DOMAIN_ID_LIST,
+            type = CommandType.LIST,
+            collectionType = CommandType.UUID,
+            entityType = DomainResponse.class,
+            required = false,
+            description = "the ID of the domains offering is associated with, null for all domain offerings",
+            since = "4.13")
+    protected List<Long> domainIds;
+
     @Parameter(name = ApiConstants.ZONE_ID_LIST,
-            type=CommandType.LIST,
+            type = CommandType.LIST,
             collectionType = CommandType.UUID,
             entityType = ZoneResponse.class,
             required = false,
-            description = "the ID of the zones offering is associated with, null for all zone offerings")
+            description = "the ID of the zones offering is associated with, null for all zone offerings",
+            since = "4.13")
     protected List<Long> zoneIds;
 
     @Parameter(name = ApiConstants.STORAGE_TYPE, type = CommandType.STRING, description = "the storage type of the disk offering. Values are local and shared.")
@@ -178,6 +188,10 @@ public class CreateDiskOfferingCmd extends BaseCmd {
 
     public Long getDomainId() {
         return domainId;
+    }
+
+    public List<Long> getDomainIds() {
+        return domainIds;
     }
 
     public List<Long> getZoneIds() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
@@ -74,7 +74,7 @@ public class CreateDiskOfferingCmd extends BaseCmd {
             required = false,
             description = "the ID of the domains offering is associated with, null for all domain offerings",
             since = "4.13")
-    protected List<Long> domainIds;
+    private List<Long> domainIds;
 
     @Parameter(name = ApiConstants.ZONE_ID_LIST,
             type = CommandType.LIST,
@@ -83,7 +83,7 @@ public class CreateDiskOfferingCmd extends BaseCmd {
             required = false,
             description = "the ID of the zones offering is associated with, null for all zone offerings",
             since = "4.13")
-    protected List<Long> zoneIds;
+    private List<Long> zoneIds;
 
     @Parameter(name = ApiConstants.STORAGE_TYPE, type = CommandType.STRING, description = "the storage type of the disk offering. Values are local and shared.")
     private String storageType = ServiceOffering.StorageType.shared.toString();

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
@@ -16,7 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.offering;
 
-import org.apache.log4j.Logger;
+import java.util.List;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
@@ -26,10 +26,12 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.DiskOfferingResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
+import org.apache.log4j.Logger;
 
-import com.cloud.storage.Storage.ProvisioningType;
 import com.cloud.offering.DiskOffering;
 import com.cloud.offering.ServiceOffering;
+import com.cloud.storage.Storage.ProvisioningType;
 import com.cloud.user.Account;
 
 @APICommand(name = "createDiskOffering", description = "Creates a disk offering.", responseObject = DiskOfferingResponse.class,
@@ -63,6 +65,14 @@ public class CreateDiskOfferingCmd extends BaseCmd {
                entityType = DomainResponse.class,
                description = "the ID of the containing domain, null for public offerings")
     private Long domainId;
+
+    @Parameter(name = ApiConstants.ZONE_ID_LIST,
+            type=CommandType.LIST,
+            collectionType = CommandType.UUID,
+            entityType = ZoneResponse.class,
+            required = false,
+            description = "the ID of the zones offering is associated with, null for all zone offerings")
+    protected List<Long> zoneIds;
 
     @Parameter(name = ApiConstants.STORAGE_TYPE, type = CommandType.STRING, description = "the storage type of the disk offering. Values are local and shared.")
     private String storageType = ServiceOffering.StorageType.shared.toString();
@@ -168,6 +178,10 @@ public class CreateDiskOfferingCmd extends BaseCmd {
 
     public Long getDomainId() {
         return domainId;
+    }
+
+    public List<Long> getZoneIds() {
+        return zoneIds;
     }
 
     public Long getBytesReadRate() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/CreateDiskOfferingCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.offering;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.cloudstack.api.APICommand;
@@ -191,6 +192,12 @@ public class CreateDiskOfferingCmd extends BaseCmd {
     }
 
     public List<Long> getDomainIds() {
+        if (domainId != null) {
+            if (domainIds == null) {
+                domainIds = new ArrayList<>();
+            }
+            domainIds.add(domainId);
+        }
         return domainIds;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.offering;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.cloudstack.api.response.DomainResponse;
@@ -116,6 +117,12 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
     }
 
     public List<Long> getDomainIds() {
+        if (domainId != null) {
+            if (domainIds == null) {
+                domainIds = new ArrayList<>();
+            }
+            domainIds.add(domainId);
+        }
         return domainIds;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -69,12 +69,22 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
             description = "the ID of the containing domain, null for public offerings")
     private Long domainId;
 
+    @Parameter(name = ApiConstants.DOMAIN_ID_LIST,
+            type = CommandType.LIST,
+            collectionType = CommandType.UUID,
+            entityType = DomainResponse.class,
+            required = false,
+            description = "the ID of the domains offering is associated with, null for all domain offerings",
+            since = "4.13")
+    protected List<Long> domainIds;
+
     @Parameter(name = ApiConstants.ZONE_ID_LIST,
-            type=CommandType.LIST,
+            type = CommandType.LIST,
             collectionType = CommandType.UUID,
             entityType = ZoneResponse.class,
             required = false,
-            description = "the ID of the zones offering is associated with, null for all zone offerings")
+            description = "the ID of the zones offering is associated with, null for all zone offerings",
+            since = "4.13")
     protected List<Long> zoneIds;
 
     /////////////////////////////////////////////////////
@@ -103,6 +113,10 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
 
     public Long getDomainId() {
         return domainId;
+    }
+
+    public List<Long> getDomainIds() {
+        return domainIds;
     }
 
     public List<Long> getZoneIds() {

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -16,6 +16,10 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.offering;
 
+import java.util.List;
+
+import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -59,6 +63,20 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
                description = "an optional field, whether to display the offering to the end user or not.")
     private Boolean displayOffering;
 
+    @Parameter(name = ApiConstants.DOMAIN_ID,
+            type = CommandType.UUID,
+            entityType = DomainResponse.class,
+            description = "the ID of the containing domain, null for public offerings")
+    private Long domainId;
+
+    @Parameter(name = ApiConstants.ZONE_ID_LIST,
+            type=CommandType.LIST,
+            collectionType = CommandType.UUID,
+            entityType = ZoneResponse.class,
+            required = false,
+            description = "the ID of the zones offering is associated with, null for all zone offerings")
+    protected List<Long> zoneIds;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -81,6 +99,14 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
 
     public Boolean getDisplayOffering() {
         return displayOffering;
+    }
+
+    public Long getDomainId() {
+        return domainId;
+    }
+
+    public List<Long> getZoneIds() {
+        return zoneIds;
     }
 
 /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -16,12 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.admin.offering;
 
-import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.cloudstack.api.response.DomainResponse;
-import org.apache.cloudstack.api.response.ZoneResponse;
-import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
@@ -30,6 +25,9 @@ import org.apache.cloudstack.api.BaseCmd;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.DiskOfferingResponse;
+import org.apache.cloudstack.api.response.DomainResponse;
+import org.apache.cloudstack.api.response.ZoneResponse;
+import org.apache.log4j.Logger;
 
 import com.cloud.offering.DiskOffering;
 import com.cloud.user.Account;
@@ -63,12 +61,6 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
                type = CommandType.BOOLEAN,
                description = "an optional field, whether to display the offering to the end user or not.")
     private Boolean displayOffering;
-
-    @Parameter(name = ApiConstants.DOMAIN_ID,
-            type = CommandType.UUID,
-            entityType = DomainResponse.class,
-            description = "the ID of the containing domain, null for public offerings")
-    private Long domainId;
 
     @Parameter(name = ApiConstants.DOMAIN_ID_LIST,
             type = CommandType.LIST,
@@ -112,17 +104,7 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
         return displayOffering;
     }
 
-    public Long getDomainId() {
-        return domainId;
-    }
-
     public List<Long> getDomainIds() {
-        if (domainId != null) {
-            if (domainIds == null) {
-                domainIds = new ArrayList<>();
-            }
-            domainIds.add(domainId);
-        }
         return domainIds;
     }
 

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/offering/UpdateDiskOfferingCmd.java
@@ -77,7 +77,7 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
             required = false,
             description = "the ID of the domains offering is associated with, null for all domain offerings",
             since = "4.13")
-    protected List<Long> domainIds;
+    private List<Long> domainIds;
 
     @Parameter(name = ApiConstants.ZONE_ID_LIST,
             type = CommandType.LIST,
@@ -86,7 +86,7 @@ public class UpdateDiskOfferingCmd extends BaseCmd {
             required = false,
             description = "the ID of the zones offering is associated with, null for all zone offerings",
             since = "4.13")
-    protected List<Long> zoneIds;
+    private List<Long> zoneIds;
 
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/offering/ListDiskOfferingsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/offering/ListDiskOfferingsCmd.java
@@ -16,6 +16,7 @@
 // under the License.
 package org.apache.cloudstack.api.command.user.offering;
 
+import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.log4j.Logger;
 
 import org.apache.cloudstack.api.APICommand;
@@ -42,6 +43,9 @@ public class ListDiskOfferingsCmd extends BaseListDomainResourcesCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "name of the disk offering")
     private String diskOfferingName;
 
+    @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class, description = "id of zone disk offering is associated with")
+    private Long zoneId;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -52,6 +56,10 @@ public class ListDiskOfferingsCmd extends BaseListDomainResourcesCmd {
 
     public String getDiskOfferingName() {
         return diskOfferingName;
+    }
+
+    public Long getZoneId() {
+        return zoneId;
     }
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/command/user/offering/ListDiskOfferingsCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/user/offering/ListDiskOfferingsCmd.java
@@ -43,7 +43,11 @@ public class ListDiskOfferingsCmd extends BaseListDomainResourcesCmd {
     @Parameter(name = ApiConstants.NAME, type = CommandType.STRING, description = "name of the disk offering")
     private String diskOfferingName;
 
-    @Parameter(name = ApiConstants.ZONE_ID, type = CommandType.UUID, entityType = ZoneResponse.class, description = "id of zone disk offering is associated with")
+    @Parameter(name = ApiConstants.ZONE_ID,
+            type = CommandType.UUID,
+            entityType = ZoneResponse.class,
+            description = "id of zone disk offering is associated with",
+            since = "4.13")
     private Long zoneId;
 
     /////////////////////////////////////////////////////

--- a/api/src/main/java/org/apache/cloudstack/api/response/DiskOfferingResponse.java
+++ b/api/src/main/java/org/apache/cloudstack/api/response/DiskOfferingResponse.java
@@ -17,8 +17,7 @@
 package org.apache.cloudstack.api.response;
 
 import java.util.Date;
-
-import com.google.gson.annotations.SerializedName;
+import java.util.Map;
 
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.BaseResponse;
@@ -26,6 +25,7 @@ import org.apache.cloudstack.api.EntityReference;
 
 import com.cloud.offering.DiskOffering;
 import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
 
 @EntityReference(value = DiskOffering.class)
 public class DiskOfferingResponse extends BaseResponse {
@@ -143,6 +143,10 @@ public class DiskOfferingResponse extends BaseResponse {
     @SerializedName("displayoffering")
     @Param(description = "whether to display the offering to the end user or not.")
     private Boolean displayOffering;
+
+    @SerializedName(ApiConstants.DETAILS)
+    @Param(description = "the details of the disk offering", since = "4.13.0")
+    private Map<String, String> details;
 
     public Boolean getDisplayOffering() {
         return displayOffering;
@@ -327,5 +331,13 @@ public class DiskOfferingResponse extends BaseResponse {
 
     public void setIopsWriteRateMaxLength(Long iopsWriteRateMaxLength) {
         this.iopsWriteRateMaxLength = iopsWriteRateMaxLength;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
     }
 }

--- a/engine/components-api/src/main/java/com/cloud/configuration/ConfigurationManager.java
+++ b/engine/components-api/src/main/java/com/cloud/configuration/ConfigurationManager.java
@@ -177,7 +177,7 @@ public interface ConfigurationManager {
 
     void checkZoneAccess(Account caller, DataCenter zone);
 
-    void checkDiskOfferingAccess(Account caller, DiskOffering dof);
+    void checkDiskOfferingAccess(Account caller, DiskOffering dof, DataCenter zone);
 
     /**
      * Creates a new network offering

--- a/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterDao.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterDao.java
@@ -121,4 +121,6 @@ public interface DataCenterDao extends GenericDao<DataCenterVO, Long> {
     List<DataCenterVO> findByKeyword(String keyword);
 
     List<DataCenterVO> listAllZones();
+
+    List<DataCenterVO> list(Object[] ids);
 }

--- a/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/dc/dao/DataCenterDaoImpl.java
@@ -437,4 +437,12 @@ public class DataCenterDaoImpl extends GenericDaoBase<DataCenterVO, Long> implem
 
         return dcs;
     }
+
+    @Override
+    public List<DataCenterVO> list(Object[] ids) {
+        SearchBuilder<DataCenterVO> sb = createSearchBuilder();
+        SearchCriteria<DataCenterVO> sc = sb.create();
+        sc.addAnd("id", SearchCriteria.Op.IN, ids);
+        return listBy(sc);
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/domain/dao/DomainDao.java
+++ b/engine/schema/src/main/java/com/cloud/domain/dao/DomainDao.java
@@ -40,4 +40,6 @@ public interface DomainDao extends GenericDao<DomainVO, Long> {
     Set<Long> getDomainParentIds(long domainId);
 
     List<Long> getDomainChildrenIds(String path);
+
+    List<DomainVO> list(Object[] ids);
 }

--- a/engine/schema/src/main/java/com/cloud/domain/dao/DomainDaoImpl.java
+++ b/engine/schema/src/main/java/com/cloud/domain/dao/DomainDaoImpl.java
@@ -291,4 +291,11 @@ public class DomainDaoImpl extends GenericDaoBase<DomainVO, Long> implements Dom
         return parentDomains;
     }
 
+    @Override
+    public List<DomainVO> list(Object[] ids) {
+        SearchBuilder<DomainVO> sb = createSearchBuilder();
+        SearchCriteria<DomainVO> sc = sb.create();
+        sc.addAnd("id", SearchCriteria.Op.IN, ids);
+        return listBy(sc);
+    }
 }

--- a/engine/schema/src/main/java/com/cloud/storage/DiskOfferingVO.java
+++ b/engine/schema/src/main/java/com/cloud/storage/DiskOfferingVO.java
@@ -51,7 +51,7 @@ public class DiskOfferingVO implements DiskOffering {
     long id;
 
     @Column(name = "domain_id")
-    Long domainId;
+    Long domainId = null;
 
     @Column(name = "unique_name")
     private String uniqueName;
@@ -180,6 +180,24 @@ public class DiskOfferingVO implements DiskOffering {
         this.minIops = minIops;
         this.maxIops = maxIops;
         this.cacheMode = cacheMode;
+    }
+
+    public DiskOfferingVO(String name, String displayText, Storage.ProvisioningType provisioningType, long diskSize, String tags, boolean isCustomized, Boolean isCustomizedIops,
+                          Long minIops, Long maxIops) {
+        this.name = name;
+        this.displayText = displayText;
+        this.provisioningType = provisioningType;
+        this.diskSize = diskSize;
+        this.tags = tags;
+        recreatable = false;
+        type = Type.Disk;
+        useLocalStorage = false;
+        customized = isCustomized;
+        uuid = UUID.randomUUID().toString();
+        customizedIops = isCustomizedIops;
+        this.minIops = minIops;
+        this.maxIops = maxIops;
+        state = State.Active;
     }
 
     public DiskOfferingVO(Long domainId, String name, String displayText, Storage.ProvisioningType provisioningType, long diskSize, String tags, boolean isCustomized, Boolean isCustomizedIops,

--- a/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
+++ b/plugins/network-elements/juniper-contrail/src/test/java/org/apache/cloudstack/network/contrail/management/MockAccountManager.java
@@ -41,6 +41,7 @@ import org.apache.cloudstack.context.CallContext;
 import com.cloud.api.query.vo.ControlledViewEntity;
 import com.cloud.configuration.ResourceLimit;
 import com.cloud.configuration.dao.ResourceCountDao;
+import com.cloud.dc.DataCenter;
 import com.cloud.domain.Domain;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.PermissionDeniedException;
@@ -435,7 +436,7 @@ public class MockAccountManager extends ManagerBase implements AccountManager {
     }
 
     @Override
-    public void checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException {
+    public void checkAccess(Account account, DiskOffering dof, DataCenter zone) throws PermissionDeniedException {
         // TODO Auto-generated method stub
     }
 

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -33,6 +33,7 @@ import org.apache.cloudstack.affinity.AffinityGroup;
 import org.apache.cloudstack.affinity.AffinityGroupResponse;
 import org.apache.cloudstack.affinity.dao.AffinityGroupDao;
 import org.apache.cloudstack.api.ApiCommandJobType;
+import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiConstants.DomainDetails;
 import org.apache.cloudstack.api.ApiConstants.HostDetails;
 import org.apache.cloudstack.api.ApiConstants.VMDetails;
@@ -68,6 +69,7 @@ import org.apache.cloudstack.framework.config.dao.ConfigurationDao;
 import org.apache.cloudstack.framework.jobs.AsyncJob;
 import org.apache.cloudstack.framework.jobs.AsyncJobManager;
 import org.apache.cloudstack.framework.jobs.dao.AsyncJobDao;
+import org.apache.cloudstack.resourcedetail.dao.DiskOfferingDetailsDao;
 import org.apache.cloudstack.storage.datastore.db.PrimaryDataStoreDao;
 import org.apache.cloudstack.storage.datastore.db.StoragePoolVO;
 
@@ -314,6 +316,7 @@ import com.cloud.vm.snapshot.VMSnapshot;
 import com.cloud.vm.snapshot.dao.VMSnapshotDao;
 import com.cloud.user.AccountManager;
 import com.cloud.network.dao.FirewallRulesDcidrsDao;
+import com.google.common.base.Strings;
 
 public class ApiDBUtils {
     private static ManagementServer s_ms;
@@ -335,6 +338,7 @@ public class ApiDBUtils {
     static CapacityDao s_capacityDao;
     static DiskOfferingDao s_diskOfferingDao;
     static DiskOfferingJoinDao s_diskOfferingJoinDao;
+    static DiskOfferingDetailsDao s_diskOfferingDetailsDao;
     static DataCenterJoinDao s_dcJoinDao;
     static DomainDao s_domainDao;
     static DomainJoinDao s_domainJoinDao;
@@ -470,6 +474,8 @@ public class ApiDBUtils {
     private DiskOfferingDao diskOfferingDao;
     @Inject
     private DiskOfferingJoinDao diskOfferingJoinDao;
+    @Inject
+    private DiskOfferingDetailsDao diskOfferingDetailsDao;
     @Inject
     private DomainDao domainDao;
     @Inject
@@ -688,6 +694,7 @@ public class ApiDBUtils {
         s_dcJoinDao = dcJoinDao;
         s_diskOfferingDao = diskOfferingDao;
         s_diskOfferingJoinDao = diskOfferingJoinDao;
+        s_diskOfferingDetailsDao = diskOfferingDetailsDao;
         s_domainDao = domainDao;
         s_domainJoinDao = domainJoinDao;
         s_domainRouterDao = domainRouterDao;
@@ -1906,7 +1913,27 @@ public class ApiDBUtils {
     }
 
     public static DiskOfferingResponse newDiskOfferingResponse(DiskOfferingJoinVO offering) {
-        return s_diskOfferingJoinDao.newDiskOfferingResponse(offering);
+        DiskOfferingResponse diskOfferingResponse = s_diskOfferingJoinDao.newDiskOfferingResponse(offering);
+        if(diskOfferingResponse!=null) {
+            Map<String, String> details = s_diskOfferingDetailsDao.listDetailsKeyPairs(offering.getId());
+            if (details != null && !details.isEmpty()) {
+                if(details.containsKey(ApiConstants.ZONE_ID_LIST) &&
+                        !Strings.isNullOrEmpty(details.get(ApiConstants.ZONE_ID_LIST))) {
+                    String[] zoneIdsArray = details.get(ApiConstants.ZONE_ID_LIST).split(",");
+                    List<DataCenterVO> zones = s_zoneDao.list(zoneIdsArray);
+                    List<String> zoneIdsList = new ArrayList<>();
+                    List<String> zoneNamesList = new ArrayList<>();
+                    for (DataCenterVO zone : zones) {
+                        zoneIdsList.add(zone.getUuid());
+                        zoneNamesList.add(zone.getName());
+                    }
+                    details.put(ApiConstants.ZONE_ID_LIST, String.join(",", zoneIdsList));
+                    details.put(ApiConstants.ZONE_NAME_LIST, String.join(", ", zoneNamesList));
+                }
+                diskOfferingResponse.setDetails(details);
+            }
+        }
+        return diskOfferingResponse;
     }
 
     public static DiskOfferingJoinVO newDiskOfferingView(DiskOffering offering) {

--- a/server/src/main/java/com/cloud/api/ApiDBUtils.java
+++ b/server/src/main/java/com/cloud/api/ApiDBUtils.java
@@ -1917,6 +1917,19 @@ public class ApiDBUtils {
         if(diskOfferingResponse!=null) {
             Map<String, String> details = s_diskOfferingDetailsDao.listDetailsKeyPairs(offering.getId());
             if (details != null && !details.isEmpty()) {
+                if(details.containsKey(ApiConstants.DOMAIN_ID_LIST) &&
+                        !Strings.isNullOrEmpty(details.get(ApiConstants.DOMAIN_ID_LIST))) {
+                    String[] domainIdsArray = details.get(ApiConstants.DOMAIN_ID_LIST).split(",");
+                    List<DomainVO> domains = s_domainDao.list(domainIdsArray);
+                    List<String> domainIdsList = new ArrayList<>();
+                    List<String> domainNamesList = new ArrayList<>();
+                    for (DomainVO domain : domains) {
+                        domainIdsList.add(domain.getUuid());
+                        domainNamesList.add(domain.getName());
+                    }
+                    details.put(ApiConstants.DOMAIN_ID_LIST, String.join(",", domainIdsList));
+                    details.put(ApiConstants.DOMAIN_NAME_LIST, String.join(", ", domainNamesList));
+                }
                 if(details.containsKey(ApiConstants.ZONE_ID_LIST) &&
                         !Strings.isNullOrEmpty(details.get(ApiConstants.ZONE_ID_LIST))) {
                     String[] zoneIdsArray = details.get(ApiConstants.ZONE_ID_LIST).split(",");

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2544,7 +2544,6 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             }
         }
 
-        List<Long> domainIds = null;
         // For non-root users, only return all offerings for the user's domain,
         // and everything above till root
         if ((_accountMgr.isNormalUser(account.getId()) || _accountMgr.isDomainAdmin(account.getId())) || account.getType() == Account.ACCOUNT_TYPE_RESOURCE_DOMAIN_ADMIN) {
@@ -2552,27 +2551,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
                 if (account.getType() == Account.ACCOUNT_TYPE_NORMAL) {
                     throw new InvalidParameterValueException("Only ROOT admins and Domain admins can list disk offerings with isrecursive=true");
                 }
-                DomainVO domainRecord = _domainDao.findById(account.getDomainId());
-                sc.addAnd("domainPath", SearchCriteria.Op.LIKE, domainRecord.getPath() + "%");
             } else { // domain + all ancestors
-                // find all domain Id up to root domain for this account
-                domainIds = new ArrayList<Long>();
-                DomainVO domainRecord = _domainDao.findById(account.getDomainId());
-                if (domainRecord == null) {
-                    s_logger.error("Could not find the domainId for account:" + account.getAccountName());
-                    throw new CloudAuthenticationException("Could not find the domainId for account:" + account.getAccountName());
-                }
-                domainIds.add(domainRecord.getId());
-                while (domainRecord.getParent() != null) {
-                    domainRecord = _domainDao.findById(domainRecord.getParent());
-                    domainIds.add(domainRecord.getId());
-                }
-
-                SearchCriteria<DiskOfferingJoinVO> spc = _diskOfferingJoinDao.createSearchCriteria();
-
-                spc.addOr("domainId", SearchCriteria.Op.IN, domainIds.toArray());
-                spc.addOr("domainId", SearchCriteria.Op.NULL); // include public offering as where
-                sc.addAnd("domainId", SearchCriteria.Op.SC, spc);
                 sc.addAnd("systemUse", SearchCriteria.Op.EQ, false); // non-root users should not see system offering at all
             }
 
@@ -2617,22 +2596,50 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
          */
 
         Pair<List<DiskOfferingJoinVO>, Integer> result = _diskOfferingJoinDao.searchAndCount(sc, searchFilter);
-        // If zoneid is passed remove offer offerings that are not associated with the zone
-        // TODO: Needs better approach
-        if (cmd.getZoneId() != null && result.first() != null && !result.first().isEmpty()) {
-            final Long zoneId = cmd.getZoneId();
+        // Remove offerings that are not associated with caller's domain and passed zone
+        // TODO: Better approach
+        if (result.first() != null && !result.first().isEmpty()) {
             List<DiskOfferingJoinVO> offerings = result.first();
             for (int i = offerings.size() - 1; i >= 0; i--) {
                 DiskOfferingJoinVO offering = offerings.get(i);
                 Map<String, String> details = diskOfferingDetailsDao.listDetailsKeyPairs(offering.getId());
-                if (details.containsKey(ApiConstants.ZONE_ID_LIST) &&
-                        !Strings.isNullOrEmpty(details.get(ApiConstants.ZONE_ID_LIST))) {
-                    String[] zoneIdsArray = details.get(ApiConstants.ZONE_ID_LIST).split(",");
-                    List<Long> zoneIds = new ArrayList<>();
-                    for (String zId : zoneIdsArray)
-                        zoneIds.add(Long.valueOf(zId.trim()));
-                    if (!zoneIds.contains(zoneId)) {
-                        offerings.remove(i);
+                boolean toRemove = isRecursive;
+                if (account.getType() != Account.ACCOUNT_TYPE_ADMIN &&
+                        details.containsKey(ApiConstants.DOMAIN_ID_LIST) &&
+                        !Strings.isNullOrEmpty(details.get(ApiConstants.DOMAIN_ID_LIST))) {
+                    toRemove = true;
+                    String[] domainIdsArray = details.get(ApiConstants.DOMAIN_ID_LIST).split(",");
+                    for (String dIdStr : domainIdsArray) {
+                        Long dId = Long.valueOf(dIdStr.trim());
+                        if(isRecursive) {
+                            if (_domainDao.isChildDomain(account.getDomainId(), dId)) {
+                                toRemove = false;
+                                break;
+                            }
+                        } else {
+                            if (_domainDao.isChildDomain(dId, account.getDomainId())) {
+                                toRemove = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+                if (toRemove) {
+                    offerings.remove(i);
+                } else {
+                    // If zoneid is passed remove offerings that are not associated with the zone
+                    if (cmd.getZoneId() != null) {
+                        final Long zoneId = cmd.getZoneId();
+                        if (details.containsKey(ApiConstants.ZONE_ID_LIST) &&
+                                !Strings.isNullOrEmpty(details.get(ApiConstants.ZONE_ID_LIST))) {
+                            String[] zoneIdsArray = details.get(ApiConstants.ZONE_ID_LIST).split(",");
+                            List<Long> zoneIds = new ArrayList<>();
+                            for (String zId : zoneIdsArray)
+                                zoneIds.add(Long.valueOf(zId.trim()));
+                            if (!zoneIds.contains(zoneId)) {
+                                offerings.remove(i);
+                            }
+                        }
                     }
                 }
             }

--- a/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
+++ b/server/src/main/java/com/cloud/api/query/QueryManagerImpl.java
@@ -2603,7 +2603,7 @@ public class QueryManagerImpl extends MutualExclusiveIdsManagerBase implements Q
             for (int i = offerings.size() - 1; i >= 0; i--) {
                 DiskOfferingJoinVO offering = offerings.get(i);
                 Map<String, String> details = diskOfferingDetailsDao.listDetailsKeyPairs(offering.getId());
-                boolean toRemove = isRecursive;
+                boolean toRemove = account.getType() == Account.ACCOUNT_TYPE_ADMIN ? false : isRecursive;
                 if (account.getType() != Account.ACCOUNT_TYPE_ADMIN &&
                         details.containsKey(ApiConstants.DOMAIN_ID_LIST) &&
                         !Strings.isNullOrEmpty(details.get(ApiConstants.DOMAIN_ID_LIST))) {

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -4236,15 +4236,15 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
     }
 
     @Override
-    public void checkDiskOfferingAccess(final Account caller, final DiskOffering dof) {
+    public void checkDiskOfferingAccess(final Account caller, final DiskOffering dof, DataCenter zone) {
         for (final SecurityChecker checker : _secChecker) {
-            if (checker.checkAccess(caller, dof)) {
+            if (checker.checkAccess(caller, dof, zone)) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Access granted to " + caller + " to disk offering:" + dof.getId() + " by " + checker.getName());
                 }
                 return;
             } else {
-                throw new PermissionDeniedException("Access denied to " + caller + " by " + checker.getName());
+                throw new PermissionDeniedException(String.format("Access denied to %s for disk offering: %s, zone: %s by %s", caller, dof.getUuid(), zone.getUuid(), checker.getName()));
             }
         }
 

--- a/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
+++ b/server/src/main/java/com/cloud/configuration/ConfigurationManagerImpl.java
@@ -2623,26 +2623,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         }
 
         // Filter child domains when both parent and child domains are present
-        List<Long> filteredDomainIds = new ArrayList<>();
-        if (domainIds != null) {
-            filteredDomainIds.addAll(domainIds);
-        }
-        if (filteredDomainIds.size() > 1) {
-            for (int i = filteredDomainIds.size() - 1; i >= 1; i--) {
-                long first = filteredDomainIds.get(i);
-                for (int j = i - 1; j >= 0; j--) {
-                    long second = filteredDomainIds.get(j);
-                    if (_domainDao.isChildDomain(filteredDomainIds.get(i), filteredDomainIds.get(j))) {
-                        filteredDomainIds.remove(j);
-                        i--;
-                    }
-                    if (_domainDao.isChildDomain(filteredDomainIds.get(j), filteredDomainIds.get(i))) {
-                        filteredDomainIds.remove(i);
-                        break;
-                    }
-                }
-            }
-        }
+        List<Long> filteredDomainIds = filterChildSubDomains(domainIds);
 
         // Check if user exists in the system
         final User user = _userDao.findById(userId);
@@ -2840,26 +2821,7 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
         final List<Long> domainIds = cmd.getDomainIds();
 
         // Filter child domains when both parent and child domains are present
-        List<Long> filteredDomainIds = new ArrayList<>();
-        if (domainIds != null) {
-            filteredDomainIds.addAll(domainIds);
-        }
-        if (filteredDomainIds.size() > 1) {
-            for (int i = filteredDomainIds.size() - 1; i >= 1; i--) {
-                long first = filteredDomainIds.get(i);
-                for (int j = i - 1; j >= 0; j--) {
-                    long second = filteredDomainIds.get(j);
-                    if (_domainDao.isChildDomain(filteredDomainIds.get(i), filteredDomainIds.get(j))) {
-                        filteredDomainIds.remove(j);
-                        i--;
-                    }
-                    if (_domainDao.isChildDomain(filteredDomainIds.get(j), filteredDomainIds.get(i))) {
-                        filteredDomainIds.remove(i);
-                        break;
-                    }
-                }
-            }
-        }
+        List<Long> filteredDomainIds = filterChildSubDomains(domainIds);
 
         if (account.getType() == Account.ACCOUNT_TYPE_DOMAIN_ADMIN) {
             if (filteredDomainIds.isEmpty()) {
@@ -5839,6 +5801,30 @@ public class ConfigurationManagerImpl extends ManagerBase implements Configurati
             }
         }
         return false;
+    }
+
+    private List<Long> filterChildSubDomains(final List<Long> domainIds) {
+        List<Long> filteredDomainIds = new ArrayList<>();
+        if (domainIds != null) {
+            filteredDomainIds.addAll(domainIds);
+        }
+        if (filteredDomainIds.size() > 1) {
+            for (int i = filteredDomainIds.size() - 1; i >= 1; i--) {
+                long first = filteredDomainIds.get(i);
+                for (int j = i - 1; j >= 0; j--) {
+                    long second = filteredDomainIds.get(j);
+                    if (_domainDao.isChildDomain(filteredDomainIds.get(i), filteredDomainIds.get(j))) {
+                        filteredDomainIds.remove(j);
+                        i--;
+                    }
+                    if (_domainDao.isChildDomain(filteredDomainIds.get(j), filteredDomainIds.get(i))) {
+                        filteredDomainIds.remove(i);
+                        break;
+                    }
+                }
+            }
+        }
+        return filteredDomainIds;
     }
 
     public List<SecurityChecker> getSecChecker() {

--- a/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
+++ b/server/src/main/java/com/cloud/storage/VolumeApiServiceImpl.java
@@ -436,11 +436,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 throw new InvalidParameterValueException("Please specify a custom sized disk offering.");
             }
 
-            if (diskOffering.getDomainId() == null) {
-                // do nothing as offering is public
-            } else {
-                _configMgr.checkDiskOfferingAccess(volumeOwner, diskOffering);
-            }
+            _configMgr.checkDiskOfferingAccess(volumeOwner, diskOffering, zone);
         }
 
         return false;
@@ -603,11 +599,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 throw new InvalidParameterValueException("This disk offering does not allow custom size");
             }
 
-            if (diskOffering.getDomainId() == null) {
-                // do nothing as offering is public
-            } else {
-                _configMgr.checkDiskOfferingAccess(caller, diskOffering);
-            }
+            _configMgr.checkDiskOfferingAccess(caller, diskOffering, _dcDao.findById(zoneId));
 
             if (diskOffering.getDiskSize() > 0) {
                 size = diskOffering.getDiskSize();
@@ -666,6 +658,9 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 // if zoneId is not provided, we default to create volume in the same zone as the snapshot zone.
                 zoneId = snapshotCheck.getDataCenterId();
             }
+
+            _configMgr.checkDiskOfferingAccess(null, diskOffering, _dcDao.findById(zoneId));
+
             size = snapshotCheck.getSize(); // ; disk offering is used for tags
             // purposes
 
@@ -949,10 +944,7 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
                 throw new InvalidParameterValueException("There are no tags on the current disk offering. The new disk offering needs to have no tags, as well.");
             }
 
-            if (newDiskOffering.getDomainId() != null) {
-                // not a public offering; check access
-                _configMgr.checkDiskOfferingAccess(CallContext.current().getCallingAccount(), newDiskOffering);
-            }
+            _configMgr.checkDiskOfferingAccess(CallContext.current().getCallingAccount(), newDiskOffering, _dcDao.findById(volume.getDataCenterId()));
 
             if (newDiskOffering.isCustomized()) {
                 newSize = cmd.getSize();
@@ -2182,7 +2174,12 @@ public class VolumeApiServiceImpl extends ManagerBase implements VolumeApiServic
             throw new InvalidParameterValueException(String.format("We cannot assign a removed disk offering [id=%s] to a volume. ", newDiskOffering.getUuid()));
         }
         Account caller = CallContext.current().getCallingAccount();
-        _accountMgr.checkAccess(caller, newDiskOffering);
+        DataCenter zone = null;
+        Volume volume = _volsDao.findById(cmd.getId());
+        if (volume != null) {
+            zone = _dcDao.findById(volume.getDataCenterId());
+        }
+        _accountMgr.checkAccess(caller, newDiskOffering, zone);
         return newDiskOffering;
     }
 

--- a/server/src/main/java/com/cloud/user/AccountManagerImpl.java
+++ b/server/src/main/java/com/cloud/user/AccountManagerImpl.java
@@ -77,6 +77,7 @@ import com.cloud.configuration.ResourceCountVO;
 import com.cloud.configuration.ResourceLimit;
 import com.cloud.configuration.dao.ResourceCountDao;
 import com.cloud.configuration.dao.ResourceLimitDao;
+import com.cloud.dc.DataCenter;
 import com.cloud.dc.DataCenterVO;
 import com.cloud.dc.DedicatedResourceVO;
 import com.cloud.dc.dao.DataCenterDao;
@@ -2844,13 +2845,15 @@ public class AccountManagerImpl extends ManagerBase implements AccountManager, M
     }
 
     @Override
-    public void checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException {
+    public void checkAccess(Account account, DiskOffering dof, DataCenter zone) throws PermissionDeniedException {
         for (SecurityChecker checker : _securityCheckers) {
-            if (checker.checkAccess(account, dof)) {
+            if (checker.checkAccess(account, dof, zone)) {
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Access granted to " + account + " to " + dof + " by " + checker.getName());
                 }
                 return;
+            } else {
+                throw new PermissionDeniedException(String.format("Access denied to %s for disk offering: %s, zone: %s by %s", account, dof.getUuid(), zone.getUuid(), checker.getName()));
             }
         }
 

--- a/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
+++ b/server/src/main/java/com/cloud/vm/UserVmManagerImpl.java
@@ -3009,7 +3009,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         // Verify that owner can use the service offering
         _accountMgr.checkAccess(owner, serviceOffering);
-        _accountMgr.checkAccess(owner, _diskOfferingDao.findById(diskOfferingId));
+        _accountMgr.checkAccess(owner, _diskOfferingDao.findById(diskOfferingId), zone);
 
         // Get default guest network in Basic zone
         Network defaultNetwork = _networkModel.getExclusiveGuestNetwork(zone.getId());
@@ -3068,7 +3068,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         // Verify that owner can use the service offering
         _accountMgr.checkAccess(owner, serviceOffering);
-        _accountMgr.checkAccess(owner, _diskOfferingDao.findById(diskOfferingId));
+        _accountMgr.checkAccess(owner, _diskOfferingDao.findById(diskOfferingId), zone);
 
         // If no network is specified, find system security group enabled network
         if (networkIdList == null || networkIdList.isEmpty()) {
@@ -3176,7 +3176,7 @@ public class UserVmManagerImpl extends ManagerBase implements UserVmManager, Vir
 
         // Verify that owner can use the service offering
         _accountMgr.checkAccess(owner, serviceOffering);
-        _accountMgr.checkAccess(owner, _diskOfferingDao.findById(diskOfferingId));
+        _accountMgr.checkAccess(owner, _diskOfferingDao.findById(diskOfferingId), zone);
 
         List<HypervisorType> vpcSupportedHTypes = _vpcMgr.getSupportedVpcHypervisors();
         if (networkIdList == null || networkIdList.isEmpty()) {

--- a/server/src/test/java/com/cloud/user/MockAccountManagerImpl.java
+++ b/server/src/test/java/com/cloud/user/MockAccountManagerImpl.java
@@ -36,6 +36,7 @@ import org.apache.cloudstack.api.command.admin.user.RegisterCmd;
 import org.apache.cloudstack.api.command.admin.user.UpdateUserCmd;
 
 import com.cloud.api.query.vo.ControlledViewEntity;
+import com.cloud.dc.DataCenter;
 import com.cloud.domain.Domain;
 import com.cloud.exception.ConcurrentOperationException;
 import com.cloud.exception.PermissionDeniedException;
@@ -217,7 +218,7 @@ public class MockAccountManagerImpl extends ManagerBase implements Manager, Acco
     }
 
     @Override
-    public void checkAccess(Account account, DiskOffering dof) throws PermissionDeniedException {
+    public void checkAccess(Account account, DiskOffering dof, DataCenter zone) throws PermissionDeniedException {
         // TODO Auto-generated method stub
     }
 

--- a/server/src/test/java/com/cloud/vpc/MockConfigurationManagerImpl.java
+++ b/server/src/test/java/com/cloud/vpc/MockConfigurationManagerImpl.java
@@ -438,7 +438,7 @@ public class MockConfigurationManagerImpl extends ManagerBase implements Configu
      * @see com.cloud.configuration.ConfigurationManager#checkDiskOfferingAccess(com.cloud.user.Account, com.cloud.offering.DiskOffering)
      */
     @Override
-    public void checkDiskOfferingAccess(Account caller, DiskOffering dof) {
+    public void checkDiskOfferingAccess(Account caller, DiskOffering dof, DataCenter zone) {
         // TODO Auto-generated method stub
 
     }

--- a/ui/l10n/en.js
+++ b/ui/l10n/en.js
@@ -705,6 +705,7 @@ var dictionary = {
 "label.dns.1":"DNS 1",
 "label.dns.2":"DNS 2",
 "label.domain":"Domain",
+"label.domains":"Domains",
 "label.domain.admin":"Domain Admin",
 "label.domain.details":"Domain details",
 "label.domain.id":"Domain ID",

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -1994,10 +1994,11 @@
                                         isChecked: false,
                                         docID: 'helpDiskOfferingPublic'
                                     },
-                                    domainId: {
+                                    domain: {
                                         label: 'label.domain',
                                         docID: 'helpDiskOfferingDomain',
                                         dependsOn: 'isPublic',
+                                        isMultiple: true,
                                         select: function(args) {
                                             $.ajax({
                                                 url: createURL('listDomains'),
@@ -2144,9 +2145,29 @@
                                 }
 
                                 if (args.data.isPublic != "on") {
-                                    $.extend(data, {
-                                        domainid: args.data.domainId
-                                    });
+                                    var domains = "";
+                                    if (Object.prototype.toString.call(args.data.domain) === '[object Array]') {
+                                        var rootDomainSelected = false;
+                                        args.data.domain.forEach(function (domain) {
+                                            if (domain === null) {
+                                                rootDomainSelected = true;
+                                                break;
+                                            }
+                                        });
+                                        if(!rootDomainSelected) {
+                                            domains = args.data.domain.join(",");
+                                        }
+                                    } else {
+                                        if (args.data.domain != null) {
+                                            domains = args.data.domain;
+                                        }
+                                    }
+                                    if (domains != "") {
+                                        $.extend(data, {
+                                            domainids: domains
+                                        });
+                                    }
+
                                     var zones = "";
                                     if (Object.prototype.toString.call(args.data.zone) === '[object Array]') {
                                         var allZonesSelected = false;
@@ -2339,8 +2360,8 @@
                                     tags: {
                                         label: 'label.storage.tags'
                                     },
-                                    domain: {
-                                        label: 'label.domain'
+                                    domains: {
+                                        label: 'label.domains'
                                     },
                                     zones: {
                                         label: 'label.zones'
@@ -2363,10 +2384,17 @@
                                     };
                                     var diskOfferings = cloudStack.listDiskOfferings(listDiskOfferingsOptions);
                                     var diskOffering = diskOfferings[0]
-                                    if(diskOffering.details && diskOffering.details.zonenames) {
-                                        $.extend(diskOffering, {
-                                            zones: diskOffering.details.zonenames
-                                        });
+                                    if(diskOffering.details) {
+                                        if(diskOffering.details.domainnames) {
+                                            $.extend(diskOffering, {
+                                                domains: diskOffering.details.domainnames
+                                            });
+                                        }
+                                        if(diskOffering.details.zonenames) {
+                                            $.extend(diskOffering, {
+                                                zones: diskOffering.details.zonenames
+                                            });
+                                        }
                                     }
                                     args.response.success({
                                         actionFilter: diskOfferingActionfilter,

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -2026,6 +2026,44 @@
                                             });
                                         },
                                         isHidden: true
+                                    },
+                                    zone: {
+                                        label: 'label.zone',
+                                        docID: 'helpDiskOfferingZone',
+                                        isMultiple: true,
+                                        isHidden: true,
+                                        dependsOn: 'isPublic',
+                                        validation: {
+                                            allzonesonly: true
+                                        },
+                                        select: function(args) {
+                                            $.ajax({
+                                                url: createURL("listZones&available=true"),
+                                                dataType: "json",
+                                                async: true,
+                                                success: function(json) {
+                                                    var zoneObjs = [];
+                                                    var items = json.listzonesresponse.zone;
+                                                    if (items != null) {
+                                                        for (var i = 0; i < items.length; i++) {
+                                                            zoneObjs.push({
+                                                                id: items[i].id,
+                                                                description: items[i].name
+                                                            });
+                                                        }
+                                                    }
+                                                    if (isAdmin()) {
+                                                        zoneObjs.unshift({
+                                                            id: -1,
+                                                            description: "All Zones"
+                                                        });
+                                                    }
+                                                    args.response.success({
+                                                        data: zoneObjs
+                                                    });
+                                                }
+                                            });
+                                        }
                                     }
                                 }
                             },
@@ -2109,6 +2147,16 @@
                                     $.extend(data, {
                                         domainid: args.data.domainId
                                     });
+                                    var zones = "";
+                                    if (Object.prototype.toString.call( args.data.zone ) === '[object Array]') {
+                                        zones = args.data.zone.join(",");
+                                    } else
+                                        zones = args.data.zone;
+                                    if (zones != "") {
+                                        $.extend(data, {
+                                            zoneids: zones
+                                        });
+                                    }
                                 }
 
                                 $.ajax({
@@ -2282,6 +2330,9 @@
                                     domain: {
                                         label: 'label.domain'
                                     },
+                                    zones: {
+                                        label: 'label.zones'
+                                    },
                                     storagetype: {
                                         label: 'label.storage.type'
                                     },
@@ -2299,6 +2350,12 @@
                                         data: data
                                     };
                                     var diskOfferings = cloudStack.listDiskOfferings(listDiskOfferingsOptions);
+                                    var diskOffering = diskOfferings[0]
+                                    if(diskOffering.details && diskOffering.details.zonenames) {
+                                        $.extend(diskOffering, {
+                                            zones: diskOffering.details.zonenames
+                                        });
+                                    }
                                     args.response.success({
                                         actionFilter: diskOfferingActionfilter,
                                         data: diskOfferings[0]

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -2032,8 +2032,6 @@
                                         label: 'label.zone',
                                         docID: 'helpDiskOfferingZone',
                                         isMultiple: true,
-                                        isHidden: true,
-                                        dependsOn: 'isPublic',
                                         validation: {
                                             allzonesonly: true
                                         },
@@ -2147,16 +2145,7 @@
                                 if (args.data.isPublic != "on") {
                                     var domains = "";
                                     if (Object.prototype.toString.call(args.data.domain) === '[object Array]') {
-                                        var rootDomainSelected = false;
-                                        args.data.domain.forEach(function (domain) {
-                                            if (domain === null) {
-                                                rootDomainSelected = true;
-                                                break;
-                                            }
-                                        });
-                                        if(!rootDomainSelected) {
-                                            domains = args.data.domain.join(",");
-                                        }
+                                        domains = args.data.domain.join(",");
                                     } else {
                                         if (args.data.domain != null) {
                                             domains = args.data.domain;
@@ -2167,29 +2156,29 @@
                                             domainids: domains
                                         });
                                     }
+                                }
 
-                                    var zones = "";
-                                    if (Object.prototype.toString.call(args.data.zone) === '[object Array]') {
-                                        var allZonesSelected = false;
-                                        args.data.zone.forEach(function (zone) {
-                                            if (zone === null) {
-                                                allZonesSelected = true;
-                                                break;
-                                            }
-                                        });
-                                        if(!allZonesSelected) {
-                                            zones = args.data.zone.join(",");
+                                var zones = "";
+                                if (Object.prototype.toString.call(args.data.zone) === '[object Array]') {
+                                    var allZonesSelected = false;
+                                    args.data.zone.forEach(function (zone) {
+                                        if (zone === null) {
+                                            allZonesSelected = true;
+                                            break;
                                         }
-                                    } else {
-                                        if (args.data.zone != null) {
-                                            zones = args.data.zone;
-                                        }
+                                    });
+                                    if(!allZonesSelected) {
+                                        zones = args.data.zone.join(",");
                                     }
-                                    if (zones != "") {
-                                        $.extend(data, {
-                                            zoneids: zones
-                                        });
+                                } else {
+                                    if (args.data.zone != null) {
+                                        zones = args.data.zone;
                                     }
+                                }
+                                if (zones != "") {
+                                    $.extend(data, {
+                                        zoneids: zones
+                                    });
                                 }
 
                                 $.ajax({

--- a/ui/scripts/configuration.js
+++ b/ui/scripts/configuration.js
@@ -2148,10 +2148,22 @@
                                         domainid: args.data.domainId
                                     });
                                     var zones = "";
-                                    if (Object.prototype.toString.call( args.data.zone ) === '[object Array]') {
-                                        zones = args.data.zone.join(",");
-                                    } else
-                                        zones = args.data.zone;
+                                    if (Object.prototype.toString.call(args.data.zone) === '[object Array]') {
+                                        var allZonesSelected = false;
+                                        args.data.zone.forEach(function (zone) {
+                                            if (zone === null) {
+                                                allZonesSelected = true;
+                                                break;
+                                            }
+                                        });
+                                        if(!allZonesSelected) {
+                                            zones = args.data.zone.join(",");
+                                        }
+                                    } else {
+                                        if (args.data.zone != null) {
+                                            zones = args.data.zone;
+                                        }
+                                    }
                                     if (zones != "") {
                                         $.extend(data, {
                                             zoneids: zones

--- a/ui/scripts/docs.js
+++ b/ui/scripts/docs.js
@@ -383,7 +383,7 @@ cloudStack.docs = {
         externalLink: ''
     },
     helpDiskOfferingDomain: {
-        desc: 'Select the subdomain in which this offering is available',
+        desc: 'Select the domains in which this offering is available (Tip: Use Ctrl to choose multiple domains)',
         externalLink: ''
     },
     helpDiskOfferingZone: {

--- a/ui/scripts/docs.js
+++ b/ui/scripts/docs.js
@@ -386,6 +386,10 @@ cloudStack.docs = {
         desc: 'Select the subdomain in which this offering is available',
         externalLink: ''
     },
+    helpDiskOfferingZone: {
+        desc: 'Select the zones in which this offering is available (Tip: Use Ctrl to choose multiple zones)',
+        externalLink: ''
+    },
     // Add domain
     helpDomainName: {
         desc: 'Any desired name for the new sub-domain. Must be unique within the current domain.',

--- a/ui/scripts/instanceWizard.js
+++ b/ui/scripts/instanceWizard.js
@@ -377,6 +377,7 @@
             // Step 4: Data disk offering
             function(args) {
                 var isRequired = (args.currentData["select-template"] == "select-iso" ? true : false);
+                var zoneid = args.currentData["zoneid"]
                 var templateFilter = 'executable'
                 if (isAdmin()) {
                     templateFilter = 'all'
@@ -384,6 +385,9 @@
                 $.ajax({
                     url: createURL("listDiskOfferings"),
                     dataType: "json",
+                    data: {
+                        zoneid: zoneid
+                    },
                     async: true,
                     success: function(json) {
                         diskOfferingObjs = json.listdiskofferingsresponse.diskoffering;

--- a/ui/scripts/storage.js
+++ b/ui/scripts/storage.js
@@ -173,7 +173,7 @@
         });
     }
 
-    var selectedDiskOfferingObj = null;
+    var diskOfferingsObjList, selectedDiskOfferingObj = null;
 
     cloudStack.sections.storage = {
         title: 'label.storage',
@@ -279,6 +279,21 @@
                                                     });
                                                 }
                                             });
+                                            args.$select.change(function() {
+                                                var diskOfferingSelect = $(this).closest('form').find('select[name=diskOffering]');
+                                                if(diskOfferingSelect) {
+                                                    $(diskOfferingSelect).find('option').remove().end();
+                                                    var data = {
+                                                        zoneid: $(this).val(),
+                                                    };
+                                                    console.log(data);
+                                                    var diskOfferings = cloudStack.listDiskOfferings({ data: data });
+                                                    diskOfferingsObjList = diskOfferings;
+                                                    $(diskOfferings).each(function() {
+                                                        $(diskOfferingSelect).append(new Option(this.displaytext, this.id));
+                                                    });
+                                                }
+                                            });
                                         }
                                     },
                                     diskOffering: {
@@ -286,6 +301,7 @@
                                         docID: 'helpVolumeDiskOffering',
                                         select: function(args) {
                                             var diskOfferings = cloudStack.listDiskOfferings({});
+                                            diskOfferingsObjList = diskOfferings;
                                             var items = [];
                                             $(diskOfferings).each(function() {
                                                 items.push({
@@ -298,7 +314,7 @@
                                             });
                                             args.$select.change(function() {
                                                 var diskOfferingId = $(this).val();
-                                                $(diskOfferings).each(function() {
+                                                $(diskOfferingsObjList).each(function() {
                                                     if (this.id == diskOfferingId) {
                                                         selectedDiskOfferingObj = this;
                                                         return false; //break the $.each() loop


### PR DESCRIPTION
## Description
**Problem**: Storage offerings cannot be linked to specified multiple domain(s) and zone(s).
**Root cause**: Storage or disk offerings are independent of zones and they can be linked to a single domain/sub-domain
**Solution**: Storage or disk offerings will be allowed to link with specified domain(s) and zone(s). Disk offering linked with multiple domains and zones can be created both with UI and API. Existing disk offerings can be updated for linking using API. Refactored createDiskOffering and updateDiskOffering API to allow passing list of domain and zone IDs with domainids and zoneids parameter respectively. UI has been refactored to allow selecting multiple domains and zones while creating disk offering using multi-select elements. Disk offering details will now show list of linked domains and zones as a comma-separated list of names. Linked domains and zones will be stored in the cloud.disk_offering_details table in database as comma-separated list of IDs with key domainids and zoneids respectively.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):
Updated create disk offering form
![Screenshot from 2019-03-27 17-12-50](https://user-images.githubusercontent.com/153340/55073459-ccfcd300-50b3-11e9-8c1a-2fc74cc893b9.png)
![Screenshot from 2019-03-27 17-11-11](https://user-images.githubusercontent.com/153340/55073466-d128f080-50b3-11e9-92c5-e5793da205c3.png)

Updated disk offering details with domains and zones,
![Screenshot from 2019-03-27 17-07-44](https://user-images.githubusercontent.com/153340/55073505-e9007480-50b3-11e9-81c6-82c161122b64.png)

Cloudmonkey API calls
![Screenshot from 2019-03-27 17-07-27](https://user-images.githubusercontent.com/153340/55073521-f0278280-50b3-11e9-8f50-c98bd6be3c26.png)
![Screenshot from 2019-03-27 17-06-14](https://user-images.githubusercontent.com/153340/55073526-f289dc80-50b3-11e9-8917-9cec20353b0d.png)


## How Has This Been Tested?
From UI and cmk


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
