### PR TITLE
[INTERNAL][POC] For vapp enabled VMs add VMware equivalent of config driveI

### DIFF
--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1949,6 +1949,25 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
             // Setup ISO device
             //
 
+            // vAPP ISO
+            if (vmSpec.getOvfProperties() != null) {
+                deviceConfigSpecArray[i] = new VirtualDeviceConfigSpec();
+                Pair<VirtualDevice, Boolean> isoInfo = VmwareHelper.prepareIsoDevice(vmMo, null, null, true, true, ideUnitNumber++, i + 1);
+                deviceConfigSpecArray[i].setDevice(isoInfo.first());
+                if (isoInfo.second()) {
+                    if (s_logger.isDebugEnabled())
+                        s_logger.debug("Prepare vApp ISO volume at existing device " + _gson.toJson(isoInfo.first()));
+
+                    deviceConfigSpecArray[i].setOperation(VirtualDeviceConfigSpecOperation.ADD);
+                } else {
+                    if (s_logger.isDebugEnabled())
+                        s_logger.debug("Prepare vApp ISO volume at existing device " + _gson.toJson(isoInfo.first()));
+
+                    deviceConfigSpecArray[i].setOperation(VirtualDeviceConfigSpecOperation.EDIT);
+                }
+                i++;
+            }
+
             // prepare systemvm patch ISO
             if (vmSpec.getType() != VirtualMachine.Type.User) {
                 // attach ISO (for patching of system VM)

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/hypervisor/vmware/resource/VmwareResource.java
@@ -1905,6 +1905,10 @@ public class VmwareResource implements StoragePoolResource, ServerResource, Vmwa
                 if (volIso == null)
                     totalChangeDevices++;
             }
+            // vApp cdrom device
+            if (vmSpec.getOvfProperties() != null) {
+                totalChangeDevices++;
+            }
 
             VirtualMachineConfigSpec vmConfigSpec = new VirtualMachineConfigSpec();
 


### PR DESCRIPTION
To allow vApp VMs, add a first empty cdrom device that can attach/run VMware equivalent of its config drive that would contain the xml.

This is only a poc, actual solution will have to consider:
- Perhaps the empty/additional cdrom could be added after the 1st/default cdrom device
- the attach/detach of user ISO etc.
- if only one IDE controller is added, what is root disk needs IDE?