### PR TITLE
Datastore cluster handle live migration disks at vCenter

### DIFF
--- a/core/src/main/java/org/apache/cloudstack/storage/to/PrimaryDataStoreTO.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/to/PrimaryDataStoreTO.java
@@ -39,7 +39,7 @@ public class PrimaryDataStoreTO implements DataStoreTO {
     public static final String REMOVE_AFTER_COPY = PrimaryDataStore.REMOVE_AFTER_COPY;
     public static final String VOLUME_SIZE = PrimaryDataStore.VOLUME_SIZE;
 
-    private final String uuid;
+    private String uuid;
     private final String name;
     private String type;
     private final long id;
@@ -73,6 +73,10 @@ public class PrimaryDataStoreTO implements DataStoreTO {
     @Override
     public String getUuid() {
         return this.uuid;
+    }
+
+    public void setUuid(String uuid) {
+        this.uuid = uuid;
     }
 
     @Override

--- a/core/src/main/java/org/apache/cloudstack/storage/to/VolumeObjectTO.java
+++ b/core/src/main/java/org/apache/cloudstack/storage/to/VolumeObjectTO.java
@@ -63,6 +63,7 @@ public class VolumeObjectTO implements DataTO {
     private MigrationOptions migrationOptions;
     private boolean directDownload;
     private boolean deployAsIs;
+    private String updatedDataStoreUUID;
 
     public VolumeObjectTO() {
 
@@ -319,4 +320,13 @@ public class VolumeObjectTO implements DataTO {
     public boolean isDeployAsIs() {
         return deployAsIs;
     }
+
+    public String getUpdatedDataStoreUUID() {
+        return updatedDataStoreUUID;
+    }
+
+    public void setUpdatedDataStoreUUID(String updatedDataStoreUUID) {
+        this.updatedDataStoreUUID = updatedDataStoreUUID;
+    }
+
 }

--- a/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
+++ b/engine/api/src/main/java/org/apache/cloudstack/engine/orchestration/service/VolumeOrchestrationService.java
@@ -134,7 +134,7 @@ public interface VolumeOrchestrationService {
 
     StoragePool findStoragePool(DiskProfile dskCh, DataCenter dc, Pod pod, Long clusterId, Long hostId, VirtualMachine vm, Set<StoragePool> avoid);
 
-    void updateVolumeDiskChain(long volumeId, String path, String chainInfo);
+    void updateVolumeDiskChain(long volumeId, String path, String chainInfo, String updatedDataStoreUUID);
 
     /**
      * Imports an existing volume for a VM into database. Useful while ingesting an unmanaged VM.

--- a/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
+++ b/engine/orchestration/src/main/java/com/cloud/vm/VirtualMachineManagerImpl.java
@@ -1491,9 +1491,9 @@ public class VirtualMachineManagerImpl extends ManagerBase implements VirtualMac
                 // Before doing this, in a certain situation, getPath() from VolumeObjectTO
                 // returned null instead of an actual path (because it was out of date with the DB).
                 if(vol.getPath() != null) {
-                    volumeMgr.updateVolumeDiskChain(vol.getId(), vol.getPath(), vol.getChainInfo());
+                    volumeMgr.updateVolumeDiskChain(vol.getId(), vol.getPath(), vol.getChainInfo(), vol.getUpdatedDataStoreUUID());
                 } else {
-                    volumeMgr.updateVolumeDiskChain(vol.getId(), volume.getPath(), vol.getChainInfo());
+                    volumeMgr.updateVolumeDiskChain(vol.getId(), volume.getPath(), vol.getChainInfo(), vol.getUpdatedDataStoreUUID());
                 }
             }
         }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDao.java
@@ -127,4 +127,6 @@ public interface PrimaryDataStoreDao extends GenericDao<StoragePoolVO, Long> {
     List<StoragePoolVO> listChildStoragePoolsInDatastoreCluster(long poolId);
 
     Integer countAll();
+
+    public List<StoragePoolVO> listPoolsByLikePath(String path);
 }

--- a/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
+++ b/engine/schema/src/main/java/org/apache/cloudstack/storage/datastore/db/PrimaryDataStoreDaoImpl.java
@@ -56,6 +56,7 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
     private final SearchBuilder<StoragePoolVO> DeleteLvmSearch;
     private final SearchBuilder<StoragePoolVO> DcLocalStorageSearch;
     private final GenericSearchBuilder<StoragePoolVO, Long> StatusCountSearch;
+    private final SearchBuilder<StoragePoolVO> PathLikeSearch;
 
     @Inject
     private StoragePoolDetailsDao _detailsDao;
@@ -132,6 +133,17 @@ public class PrimaryDataStoreDaoImpl extends GenericDaoBase<StoragePoolVO, Long>
         DcLocalStorageSearch.and("path", DcLocalStorageSearch.entity().getPath(), SearchCriteria.Op.EQ);
         DcLocalStorageSearch.and("scope", DcLocalStorageSearch.entity().getScope(), SearchCriteria.Op.EQ);
         DcLocalStorageSearch.done();
+
+        PathLikeSearch = createSearchBuilder();
+        PathLikeSearch.and("path", PathLikeSearch.entity().getPath(), SearchCriteria.Op.LIKE);
+        PathLikeSearch.done();
+    }
+
+    @Override
+    public List<StoragePoolVO> listPoolsByLikePath(String path) {
+        SearchCriteria<StoragePoolVO> sc = PathLikeSearch.create();
+        sc.setParameters("path", "%" + path + "%");
+        return listBy(sc);
     }
 
     @Override

--- a/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
+++ b/plugins/hypervisors/vmware/src/main/java/com/cloud/storage/resource/VmwareStorageProcessor.java
@@ -35,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import com.cloud.hypervisor.vmware.mo.VirtualStorageObjectManagerMO;
+import com.cloud.hypervisor.vmware.mo.VirtualMachineDiskInfoBuilder;
 import com.vmware.vim25.BaseConfigInfoDiskFileBackingInfo;
 import com.vmware.vim25.VStorageObject;
 import com.vmware.vim25.VirtualDiskType;
@@ -2077,6 +2078,7 @@ public class VmwareStorageProcessor implements StorageProcessor {
 
             DatastoreMO dsMo = new DatastoreMO(context, morDs);
             String datastoreVolumePath;
+            boolean datastoreChangeObserved = false;
 
             if (isAttach) {
                 if (isManaged) {
@@ -2102,6 +2104,25 @@ public class VmwareStorageProcessor implements StorageProcessor {
                 if (isManaged) {
                     datastoreVolumePath = dsMo.getDatastorePath((vmdkPath != null ? vmdkPath : dsMo.getName()) + ".vmdk");
                 } else {
+                    String datastoreUUID = primaryStore.getUuid();
+                    if (disk.getDetails().get(DiskTO.PROTOCOL_TYPE) != null && disk.getDetails().get(DiskTO.PROTOCOL_TYPE).equalsIgnoreCase("DatastoreCluster")) {
+                        DatastoreMO diskDatastoreMoFromVM = getDiskDatastoreMofromVM(hyperHost, context, vmMo, disk);
+                        if (diskDatastoreMoFromVM != null) {
+                            String actualPoolUuid = diskDatastoreMoFromVM.getCustomFieldValue(CustomFieldConstants.CLOUD_UUID);
+                            if (!actualPoolUuid.equalsIgnoreCase(primaryStore.getUuid())) {
+                                s_logger.warn(String.format("Volume %s found to be in a different storage pool %s", volumeTO.getPath(), actualPoolUuid));
+                                datastoreChangeObserved = true;
+                                datastoreUUID = actualPoolUuid;
+                            }
+                        }
+                    }
+                    if (storagePort == DEFAULT_NFS_PORT) {
+                        morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, isManaged ? VmwareResource.getDatastoreName(diskUuid) : datastoreUUID);
+                    } else {
+                        morDs = HypervisorHostHelper.findDatastoreWithBackwardsCompatibility(hyperHost, isManaged ? VmwareResource.getDatastoreName(iScsiName) : datastoreUUID);
+                    }
+                    dsMo = new DatastoreMO(context, morDs);
+
                     datastoreVolumePath = VmwareStorageLayoutHelper.getLegacyDatastorePathFromVmdkFileName(dsMo, volumeTO.getPath() + ".vmdk");
                     if (!dsMo.fileExists(datastoreVolumePath)) {
                         datastoreVolumePath = VmwareStorageLayoutHelper.getVmwareDatastorePathFromVmdkFileName(dsMo, vmName, volumeTO.getPath() + ".vmdk");
@@ -2143,6 +2164,8 @@ public class VmwareStorageProcessor implements StorageProcessor {
                         VmwareStorageLayoutHelper.syncVolumeToRootFolder(dsMo.getOwnerDatacenter().first(), dsMo, volumeTO.getPath(), vmName, VmwareManager.s_vmwareSearchExcludeFolder.value());
                     }
                 }
+                if (datastoreChangeObserved)
+                    answer.setContextParam("datastoreName", dsMo.getName());
             }
 
             return answer;
@@ -2166,6 +2189,44 @@ public class VmwareStorageProcessor implements StorageProcessor {
 
             return new AttachAnswer(msg);
         }
+    }
+
+    private DatastoreMO getDiskDatastoreMofromVM(VmwareHypervisorHost hyperHost, VmwareContext context,
+                                                 VirtualMachineMO vmMo, DiskTO disk) throws Exception {
+        assert (hyperHost != null) && (context != null);
+        List<Pair<Integer, ManagedObjectReference>> diskDatastores = vmMo.getAllDiskDatastores();
+        VirtualMachineDiskInfoBuilder diskInfoBuilder = vmMo.getDiskInfoBuilder();
+        VolumeObjectTO volume = (VolumeObjectTO) disk.getData();
+        String diskBackingFileBaseName = volume.getPath();
+        for (Pair<Integer, ManagedObjectReference> diskDatastore : diskDatastores) {
+            DatastoreMO dsMo = new DatastoreMO(hyperHost.getContext(), diskDatastore.second());
+            String dsName = dsMo.getName();
+
+            VirtualMachineDiskInfo diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(diskBackingFileBaseName, dsName);
+            if (diskInfo != null) {
+                s_logger.info("Found existing disk info from volume path: " + volume.getPath());
+                return dsMo;
+            } else {
+                String chainInfo = volume.getChainInfo();
+                if (chainInfo != null) {
+                    VirtualMachineDiskInfo infoInChain = _gson.fromJson(chainInfo, VirtualMachineDiskInfo.class);
+                    if (infoInChain != null) {
+                        String[] disks = infoInChain.getDiskChain();
+                        if (disks.length > 0) {
+                            for (String diskPath : disks) {
+                                DatastoreFile file = new DatastoreFile(diskPath);
+                                diskInfo = diskInfoBuilder.getDiskInfoByBackingFileBaseName(file.getFileBaseName(), dsName);
+                                if (diskInfo != null) {
+                                    s_logger.info("Found existing disk from chain info: " + diskPath);
+                                    return dsMo;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     private boolean expandVirtualDisk(VirtualMachineMO vmMo, String datastoreVolumePath, long currentSizeInBytes) throws Exception {

--- a/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
+++ b/vmware-base/src/main/java/com/cloud/hypervisor/vmware/mo/VirtualMachineMO.java
@@ -2633,7 +2633,7 @@ public class VirtualMachineMO extends BaseMO {
                     VirtualDeviceBackingInfo backingInfo = ((VirtualDisk)device).getBacking();
                     if (backingInfo instanceof VirtualDiskFlatVer2BackingInfo) {
                         VirtualDiskFlatVer2BackingInfo diskBackingInfo = (VirtualDiskFlatVer2BackingInfo)backingInfo;
-                        disks.add(new Pair<Integer, ManagedObjectReference>(new Integer(device.getKey()), diskBackingInfo.getDatastore()));
+                        disks.add(new Pair<Integer, ManagedObjectReference>(new Integer(device.getUnitNumber()), diskBackingInfo.getDatastore()));
                     }
                 }
             }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fixing the issue, cannot start a stopped VM on Datastore Cluster as the disk is not on CloudStack intended datastore inside datastore cluster. This is due to datastore cluster has the ability to migrate disk across datastores inside datastore cluster.
Handling the situation while starting the VM to check if the volumes are on on intended datastore if not consider the actual datastore as on vCenter.

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

## Screenshots (if appropriate):

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->


<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
