### PR TITLE
Added disk provisioning type support for VMWare

### DIFF
--- a/api/src/main/java/com/cloud/agent/api/StoragePoolInfo.java
+++ b/api/src/main/java/com/cloud/agent/api/StoragePoolInfo.java
@@ -107,4 +107,8 @@ public class StoragePoolInfo {
     public Map<String, String> getDetails() {
         return details;
     }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
+    }
 }

--- a/api/src/main/java/com/cloud/storage/StorageService.java
+++ b/api/src/main/java/com/cloud/storage/StorageService.java
@@ -104,4 +104,6 @@ public interface StorageService {
 
     ImageStore updateImageStoreStatus(Long id, Boolean readonly);
 
+    void syncHardwareCapability(long poolId);
+
 }

--- a/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/UpdateStorageCapabilitiesCmd.java
+++ b/api/src/main/java/org/apache/cloudstack/api/command/admin/storage/UpdateStorageCapabilitiesCmd.java
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package org.apache.cloudstack.api.command.admin.storage;
+
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.StoragePoolResponse;
+import org.apache.cloudstack.api.response.SuccessResponse;
+import org.apache.cloudstack.context.CallContext;
+
+@APICommand(name = UpdateStorageCapabilitiesCmd.APINAME, description = "Syncs hardware acceleration capabilities of storage pools",
+        responseObject = SuccessResponse.class,
+        requestHasSensitiveInfo = false, responseHasSensitiveInfo = false)
+public class UpdateStorageCapabilitiesCmd extends BaseCmd {
+    public static final String APINAME = "updateStorageCapabilities";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID, entityType = StoragePoolResponse.class, required = true, description = "Storage pool id")
+    private Long poolId;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getPoolId() {
+        return poolId;
+    }
+
+    public void setPoolId(Long poolId) {
+        this.poolId = poolId;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        _storageService.syncHardwareCapability(poolId);
+        SuccessResponse response = new SuccessResponse(getCommandName());
+        response.setSuccess(true);
+        this.setResponseObject(response);
+    }
+
+    @Override
+    public String getCommandName() {
+        return APINAME;
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return CallContext.current().getCallingAccountId();
+    }
+}

--- a/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
+++ b/engine/storage/volume/src/main/java/org/apache/cloudstack/storage/datastore/provider/DefaultHostListener.java
@@ -166,6 +166,13 @@ public class DefaultHostListener implements HypervisorHostListener {
                 storagePoolDetailsDao.persist(storagePoolDetailVO);
             }
         }
+        if (mspAnswer.getPoolInfo().getDetails() != null && mspAnswer.getPoolInfo().getDetails().containsKey("hardwareAccelerationSupported")){
+            StoragePoolDetailVO hardwareAccelerationSupported = storagePoolDetailsDao.findDetail(pool.getId(), "hardwareAccelerationSupported");
+            if (hardwareAccelerationSupported == null) {
+                StoragePoolDetailVO storagePoolDetailVO = new StoragePoolDetailVO(pool.getId(), "hardwareAccelerationSupported", mspAnswer.getPoolInfo().getDetails().get("hardwareAccelerationSupported"), false);
+                storagePoolDetailsDao.persist(storagePoolDetailVO);
+            }
+        }
         primaryStoreDao.update(pool.getId(), poolVO);
     }
 

--- a/server/src/main/java/com/cloud/server/ManagementServerImpl.java
+++ b/server/src/main/java/com/cloud/server/ManagementServerImpl.java
@@ -203,6 +203,7 @@ import org.apache.cloudstack.api.command.admin.storage.MigrateSecondaryStorageDa
 import org.apache.cloudstack.api.command.admin.storage.PreparePrimaryStorageForMaintenanceCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateCloudToUseObjectStoreCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateImageStoreCmd;
+import org.apache.cloudstack.api.command.admin.storage.UpdateStorageCapabilitiesCmd;
 import org.apache.cloudstack.api.command.admin.storage.UpdateStoragePoolCmd;
 import org.apache.cloudstack.api.command.admin.swift.AddSwiftCmd;
 import org.apache.cloudstack.api.command.admin.swift.ListSwiftsCmd;
@@ -729,6 +730,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
     static final ConfigKey<Integer> vmPasswordLength = new ConfigKey<Integer>("Advanced", Integer.class, "vm.password.length", "6", "Specifies the length of a randomly generated password", false);
     static final ConfigKey<Integer> sshKeyLength = new ConfigKey<Integer>("Advanced", Integer.class, "ssh.key.length", "2048", "Specifies custom SSH key length (bit)", true, ConfigKey.Scope.Global);
     static final ConfigKey<Boolean> humanReadableSizes = new ConfigKey<Boolean>("Advanced", Boolean.class, "display.human.readable.sizes", "true", "Enables outputting human readable byte sizes to logs and usage records.", false, ConfigKey.Scope.Global);
+    static final ConfigKey<Boolean> diskProvisioningStrictness = new ConfigKey<Boolean>("Storage", Boolean.class, "disk.provisioning.type.strictness", "false", "Use storage pools only with supported disk provisioning types for disk/service offerings.", true, ConfigKey.Scope.Zone);
 
     @Inject
     public AccountManager _accountMgr;
@@ -2809,6 +2811,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
         cmdList.add(FindStoragePoolsForMigrationCmd.class);
         cmdList.add(PreparePrimaryStorageForMaintenanceCmd.class);
         cmdList.add(UpdateStoragePoolCmd.class);
+        cmdList.add(UpdateStorageCapabilitiesCmd.class);
         cmdList.add(UpdateImageStoreCmd.class);
         cmdList.add(DestroySystemVmCmd.class);
         cmdList.add(ListSystemVMsCmd.class);
@@ -3225,7 +3228,7 @@ public class ManagementServerImpl extends ManagerBase implements ManagementServe
 
     @Override
     public ConfigKey<?>[] getConfigKeys() {
-        return new ConfigKey<?>[] {vmPasswordLength, sshKeyLength, humanReadableSizes};
+        return new ConfigKey<?>[] {vmPasswordLength, sshKeyLength, humanReadableSizes, diskProvisioningStrictness};
     }
 
     protected class EventPurgeTask extends ManagedContextRunnable {

--- a/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
+++ b/server/src/main/java/com/cloud/storage/StorageManagerImpl.java
@@ -114,6 +114,7 @@ import com.cloud.agent.api.DeleteStoragePoolCommand;
 import com.cloud.agent.api.StoragePoolInfo;
 import com.cloud.agent.api.to.DataTO;
 import com.cloud.agent.api.to.DiskTO;
+import com.cloud.agent.api.ModifyStoragePoolCommand;
 import com.cloud.agent.manager.Commands;
 import com.cloud.api.ApiDBUtils;
 import com.cloud.api.query.dao.TemplateJoinDao;
@@ -303,7 +304,11 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
     @Inject
     SnapshotService _snapshotService;
     @Inject
+    public StorageService storageService;
+    @Inject
     StoragePoolTagsDao _storagePoolTagsDao;
+    @Inject
+    PrimaryDataStoreDao primaryStoreDao;
     @Inject
     DiskOfferingDetailsDao _diskOfferingDetailsDao;
     @Inject
@@ -2329,6 +2334,17 @@ public class StorageManagerImpl extends ManagerBase implements StorageManager, C
         imageStoreVO.setReadonly(readonly);
         _imageStoreDao.update(id, imageStoreVO);
         return imageStoreVO;
+    }
+
+    @Override
+    public void syncHardwareCapability(long poolId) {
+        StoragePoolVO pool = _storagePoolDao.findById(poolId);
+        // find the host
+        List<StoragePoolHostVO> hosts = _storagePoolHostDao.listByPoolId(poolId);
+        if (hosts.size() > 0) {
+            StoragePoolHostVO host = hosts.get(0);
+            _agentMgr.easySend(host.getHostId(), new ModifyStoragePoolCommand(false, pool));
+        }
     }
 
     private void duplicateCacheStoreRecordsToRegionStore(long storeId) {

--- a/test/integration/smoke/test_disk_offerings.py
+++ b/test/integration/smoke/test_disk_offerings.py
@@ -19,7 +19,6 @@
 #Import Local Modules
 import marvin
 from marvin.cloudstackTestCase import *
-from marvin.cloudstackAPI import *
 from marvin.lib.utils import *
 from marvin.lib.base import *
 from marvin.lib.common import *
@@ -134,7 +133,7 @@ class TestCreateDiskOffering(cloudstackTestCase):
     @attr(hypervisor="kvm")
     @attr(tags = ["advanced", "basic", "eip", "sg", "advancedns", "simulator", "smoke"])
     def test_04_create_fat_type_disk_offering(self):
-        """Test to create  a sparse type disk offering"""
+        """Test to create a sparse type disk offering"""
 
         # Validate the following:
         # 1. createDiskOfferings should return valid info for new offering

--- a/test/integration/smoke/test_disk_provisioning_types.py
+++ b/test/integration/smoke/test_disk_provisioning_types.py
@@ -1,0 +1,142 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from marvin.cloudstackTestCase import cloudstackTestCase
+from marvin.lib.utils import cleanup_resources
+from marvin.lib.base import DiskOffering, Iso, Account, VirtualMachine, ServiceOffering, Volume
+from marvin.codes import FAILED
+from marvin.lib.common import list_disk_offering, get_zone, get_suitable_test_template, get_domain
+from marvin.cloudstackAPI import listStoragePools, updateStorageCapabilities
+from nose.plugins.attrib import attr
+
+
+class TestDiskProvisioningTypes(cloudstackTestCase):
+
+    def setUp(self):
+        self.services = self.testClient.getParsedTestDataConfig()
+        self.apiclient = self.testClient.getApiClient()
+        self.dbclient = self.testClient.getDbConnection()
+        self.zone = get_zone(self.apiclient, self.testClient.getZoneForTests())
+        self.domain = get_domain(self.apiclient)
+        self.services['mode'] = self.zone.networktype
+        self.hypervisor = self.hypervisor = self.testClient.getHypervisorInfo()
+
+        template = get_suitable_test_template(
+            self.apiclient,
+            self.zone.id,
+            self.services["ostype"],
+            self.hypervisor
+        )
+
+        if template == FAILED:
+            assert False, "get_suitable_test_template() failed to return template with description %s" % self.services["ostype"]
+
+        self.account = Account.create(
+            self.apiclient,
+            self.services["account"],
+            domainid=self.domain.id
+        )
+
+        self.services["small"]["zoneid"] = self.zone.id
+        self.services["small"]["template"] = template.id
+
+        self.services["iso1"]["zoneid"] = self.zone.id
+
+        iso = Iso.create(
+            self.apiclient,
+            self.services["iso1"],
+            account=self.account.name,
+            domainid=self.account.domainid
+        )
+
+        self.cleanup = [
+            self.account
+        ]
+
+
+    def tearDown(self):
+        cleanup_resources(self.apiclient, self.cleanup)
+
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke"], required_hardware="false")
+    def test_01_vm_with_thin_disk_offering(self):
+        self.runner("thin")
+
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke"], required_hardware="false")
+    def test_02_vm_with_fat_disk_offering(self):
+        self.runner("fat")
+
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke"], required_hardware="false")
+    def test_03_vm_with_sparse_disk_offering(self):
+        self.runner("sparse")
+
+    @attr(tags=["advanced", "basic", "eip", "sg", "advancedns", "smoke"], required_hardware="false")
+    def test_05_update_cmd(self):
+        cmd = listStoragePools.listStoragePoolsCmd()
+        storagePools = self.apiclient.listStoragePools(cmd)
+        pool = storagePools[0]
+        cmd = updateStorageCapabilities.updateStorageCapabilitiesCmd()
+        cmd.id = pool.id
+        response = self.apiclient.updateStorageCapabilities(cmd)
+        self.assertEqual(
+            response['success'],
+            True,
+            "Check Updated storage pool capabilities"
+        )
+
+    def runner(self, provisioning_type):
+        self.services["disk_offering"]['provisioningtype'] = provisioning_type
+        self.services["small"]['size'] = "1"
+        disk_offering = DiskOffering.create(
+            self.apiclient,
+            self.services["disk_offering"],
+            custom=True,
+        )
+        self.cleanup.append(disk_offering)
+
+        self.debug("Created Disk offering with ID: %s" % disk_offering.id)
+
+        self.services["service_offerings"]["small"]["provisioningtype"] = provisioning_type
+        small_offering = ServiceOffering.create(
+            self.apiclient,
+            self.services["service_offerings"]["small"]
+        )
+
+        self.cleanup.append(small_offering)
+
+        self.debug("Created service offering with ID: %s" % small_offering.id)
+
+        virtual_machine = VirtualMachine.create(
+            self.apiclient,
+            self.services["small"],
+            accountid=self.account.name,
+            domainid=self.account.domainid,
+            serviceofferingid=small_offering.id,
+            diskofferingid=disk_offering.id,
+            mode=self.services["mode"]
+        )
+
+        self.debug("Created virtual machine with ID: %s" % virtual_machine.id)
+
+        volumes = Volume.list(self.apiclient, virtualMachineId=virtual_machine.id, listAll='true')
+
+        for volume in volumes:
+            if volume["type"] == "DATADISK":
+                VirtualMachine.detach_volume(virtual_machine, self.apiclient, volume)
+                currentVolume = Volume({})
+                currentVolume.id = volume.id
+                Volume.resize(currentVolume, self.apiclient, size='2')
+                VirtualMachine.attach_volume(virtual_machine, self.apiclient, volume)

--- a/tools/apidoc/gen_toc.py
+++ b/tools/apidoc/gen_toc.py
@@ -95,6 +95,7 @@ known_categories = {
     'StorageMaintenance': 'Storage Pool',
     'StoragePool': 'Storage Pool',
     'StorageProvider': 'Storage Pool',
+    'syncStorageCapabilites' : 'Storage Pool',
     'SecurityGroup': 'Security Group',
     'SSH': 'SSH',
     'register': 'Registration',

--- a/tools/marvin/marvin/lib/base.py
+++ b/tools/marvin/marvin/lib/base.py
@@ -632,6 +632,9 @@ class VirtualMachine:
         if rootdiskcontroller:
             cmd.details[0]["rootDiskController"] = rootdiskcontroller
 
+        if "size" in services:
+            cmd.size = services["size"]
+
         if group:
             cmd.group = group
 
@@ -2293,6 +2296,9 @@ class ServiceOffering:
 
         if "offerha" in services:
             cmd.offerha = services["offerha"]
+
+        if "provisioningtype" in services:
+            cmd.provisioningtype = services["provisioningtype"]
 
         # Service Offering private to that domain
         if domainid:


### PR DESCRIPTION
### Description

This PR adds the ability to create thick and sparse disks using VMWare

A global variable (disk.provisioning.type.strictness) has been added to select if disk provisioning types will be strictly adhered to, meaning if a storage pool is not capable of creating the specific disk provisioning type, the pool will not be selected for the creation of the VM.

StoragePool capabilities are determined when the pool is added to Cloudstack and a new API is added ( updateStorageCapabilities(poolId) ) to update the hardware acceleration capability of storage pools if needed. 

<!--- Describe your changes in DETAIL - And how has behaviour functionally changed. -->

<!-- For new features, provide link to FS, dev ML discussion etc. -->
<!-- In case of bug fix, the expected and actual behaviours, steps to reproduce. -->

<!-- When "Fixes: #<id>" is specified, the issue/PR will automatically be closed when this PR gets merged -->
<!-- For addressing multiple issues/PRs, use multiple "Fixes: #<id>" -->
<!-- Fixes: # -->

<!--- ********************************************************************************* -->
<!--- NOTE: AUTOMATATION USES THE DESCRIPTIONS TO SET LABELS AND PRODUCE DOCUMENTATION. -->
<!--- PLEASE PUT AN 'X' in only **ONE** box -->
<!--- ********************************************************************************* -->

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Major
- [ ] Minor

### Screenshots (if appropriate):

### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Marvin tests have been added and manual tests have been done using NFS without hardware acceleration and an ISCSI datastore.

Create a thin/sparse/thick disk/service offering, set the global var to true, depending on the offering selected, the disks should be created in the correct storage pool with the correct disk provisioning type.

If the global var is set to false, the disk will be created in any storage pool and if the pool supports the disk provisioning type it will be used, otherwise thin will be selected.

<!-- Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/master/CONTRIBUTING.md) document -->
