### PR TITLE
Exclude log4j from transitive dependencies

### DIFF
--- a/plugins/network-elements/juniper-contrail/pom.xml
+++ b/plugins/network-elements/juniper-contrail/pom.xml
@@ -112,6 +112,12 @@
             <groupId>net.juniper.contrail</groupId>
             <artifactId>juniper-contrail-api</artifactId>
             <version>1.0-SNAPSHOT</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>

--- a/plugins/user-authenticators/ldap/pom.xml
+++ b/plugins/user-authenticators/ldap/pom.xml
@@ -175,6 +175,10 @@
             <version>${ads.version}</version>
             <scope>test</scope>
             <exclusions>
+                <exclusion>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
                 <!--
                  shared-ldap-schema module needs to be excluded to avoid multiple schema resources on the classpath
                 -->

--- a/pom.xml
+++ b/pom.xml
@@ -618,6 +618,12 @@
                 <groupId>org.owasp.esapi</groupId>
                 <artifactId>esapi</artifactId>
                 <version>2.1.0.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Test dependency in mysql for db tests -->
             <dependency>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -144,6 +144,10 @@
             <artifactId>esapi</artifactId>
             <exclusions>
                 <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>xml-apis</groupId>
                     <artifactId>xml-apis</artifactId>
                 </exclusion>


### PR DESCRIPTION
Excludes log4j from transitive dependencies


`mvn dependency:tree -Dincludes=log4j:log4j:jar | grep log4j` comes back clean after this, have not tested functionality though.
