### PR TITLE
Harden LDAP config discovery during login

### DIFF
--- a/ui/src/store/modules/user.js
+++ b/ui/src/store/modules/user.js
@@ -219,7 +219,7 @@ const user = {
           commit('SET_PROJECT', {})
           commit('SET_HEADER_NOTICES', [])
           commit('SET_FEATURES', {})
-          commit('SET_LDAP', {})
+          commit('SET_LDAP', false)
           commit('SET_CLOUDIAN', {})
           commit('SET_DOMAIN_STORE', {})
           commit('SET_LOGOUT_FLAG', false)
@@ -268,7 +268,7 @@ const user = {
           commit('SET_PROJECT', {})
           commit('SET_HEADER_NOTICES', [])
           commit('SET_FEATURES', {})
-          commit('SET_LDAP', {})
+          commit('SET_LDAP', false)
           commit('SET_CLOUDIAN', {})
           commit('SET_DOMAIN_STORE', {})
           commit('SET_LOGOUT_FLAG', false)
@@ -420,9 +420,10 @@ const user = {
         })
 
         api('listLdapConfigurations').then(response => {
-          const ldapEnable = (response.ldapconfigurationresponse.count > 0)
+          const ldapEnable = ((response && response.ldapconfigurationresponse && response.ldapconfigurationresponse.count) || 0) > 0
           commit('SET_LDAP', ldapEnable)
         }).catch(ignored => {
+          commit('SET_LDAP', false)
         })
 
         api('cloudianIsEnabled').then(response => {
@@ -447,7 +448,7 @@ const user = {
         commit('SET_PROJECT', {})
         commit('SET_HEADER_NOTICES', [])
         commit('SET_FEATURES', {})
-        commit('SET_LDAP', {})
+        commit('SET_LDAP', false)
         commit('SET_CLOUDIAN', {})
         commit('RESET_THEME')
         commit('SET_DOMAIN_STORE', {})
@@ -553,8 +554,9 @@ const user = {
     UpdateLdapConfigurationFlag ({ commit }) {
       return new Promise((resolve, reject) => {
         api('listLdapConfigurations').then(response => {
-          const ldapEnable = (response.ldapconfigurationresponse.count > 0)
+          const ldapEnable = ((response && response.ldapconfigurationresponse && response.ldapconfigurationresponse.count) || 0) > 0
           commit('SET_LDAP', ldapEnable)
+          resolve(ldapEnable)
         }).catch(error => {
           reject(error)
         })

--- a/ui/src/utils/request.js
+++ b/ui/src/utils/request.js
@@ -51,7 +51,7 @@ const err = (error) => {
       })
     }
     if (response.status === 401) {
-      if (response.config && response.config.params && ['forgotPassword', 'listIdps', 'cloudianIsEnabled'].includes(response.config.params.command)) {
+      if (response.config && response.config.params && ['forgotPassword', 'listIdps', 'cloudianIsEnabled', 'listLdapConfigurations'].includes(response.config.params.command)) {
         return
       }
       const originalPath = router.currentRoute.value.fullPath


### PR DESCRIPTION
This stacks on top of apache/cloudstack#13152 and keeps the existing login-flow fix, while tightening a few edge cases found during review/testing.

Changes:
- Reset LDAP state with boolean `false` instead of `{}` during login/logout initialization.
- When `listLdapConfigurations` is unavailable during `GetInfo`, explicitly set `SET_LDAP` to `false` instead of leaving the previous truthy placeholder.
- Guard LDAP count parsing so an ignored 401 response does not throw from the `then` handler.
- Resolve `UpdateLdapConfigurationFlag` on success so callers waiting on the dispatch do not hang.
- Suppress the generic 401 notification for `listLdapConfigurations`, matching other optional discovery probes.

Validation:
- `node --check ui/src/store/modules/user.js`
- `node --check ui/src/utils/request.js`
- `git diff --check`